### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   test:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/gbleu/ok-pour-moi/security/code-scanning/1](https://github.com/gbleu/ok-pour-moi/security/code-scanning/1)

Generally, the fix is to add an explicit `permissions` block to the workflow or to the specific job to constrain `GITHUB_TOKEN` to the least privileges needed. For a test-and-coverage CI workflow that only checks out code and uploads coverage to Codecov using a separate secret token, `contents: read` is sufficient.

The single best fix here, without changing functionality, is to add a job-level `permissions` block under `jobs.test`, just above `runs-on`. That restricts the token for this job while allowing other future jobs to opt into different permissions if necessary. We’ll set:
```yaml
permissions:
  contents: read
```
This gives the actions (notably `actions/checkout@v4`) read access to the repository contents, which is required, but no write access. No other scopes (e.g., `pull-requests`, `issues`) are currently needed by the shown steps. The change is confined to `.github/workflows/ci.yml`, inserting the new block between lines 10 and 11.

No additional imports, methods, or definitions are needed, since this is a YAML workflow configuration change only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
