### PR TITLE
Add github-actions to dependabot and switch to daily schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,12 @@
 
 version: 2
 updates:
-  - package-ecosystem: "bun" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "bun"
+    directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
## Summary
- Add `github-actions` package ecosystem to dependabot
- Change schedule from weekly to daily for both bun and github-actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)