### PR TITLE
Fix code review issues: error handling, tests, and performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ mkdir -p ~/.ok-pour-moi
 cp /path/to/your/signature.png ~/.ok-pour-moi/signature.png
 ```
 
+Supported formats: `.png`, `.jpg`, `.jpeg`
+
 ### 4. Create Outlook folder
 
 In Outlook web, create a folder named `ok pour moi` (or customize via `OPM_OUTLOOK_FOLDER` in `.env`).
@@ -42,7 +44,9 @@ To quickly move emails to the folder:
 cp .env.example .env
 ```
 
-Edit `.env` with your settings. Required variables:
+Edit `.env` with your settings.
+
+**Required variables:**
 
 | Variable               | Description                                       |
 | ---------------------- | ------------------------------------------------- |
@@ -52,6 +56,16 @@ Edit `.env` with your settings. Required variables:
 | `OPM_SIGNATURE_WIDTH`  | Signature width in pixels                         |
 | `OPM_SIGNATURE_HEIGHT` | Signature height in pixels                        |
 | `OPM_REPLY_MESSAGE`    | Message text for the reply                        |
+
+**Optional variables:**
+
+| Variable             | Default                        | Description                        |
+| -------------------- | ------------------------------ | ---------------------------------- |
+| `OPM_OUTLOOK_FOLDER` | `ok pour moi`                  | Outlook folder to process          |
+| `OPM_SIGNATURE_PATH` | `~/.ok-pour-moi/signature.png` | Path to signature image            |
+| `OPM_CC_EMAILS`      | (empty)                        | Comma-separated CC email addresses |
+| `OPM_CC_ENABLED`     | `false`                        | Enable CC recipients               |
+| `OPM_HEADLESS`       | (unset)                        | Run browser in headless mode       |
 
 ## Usage
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import { formatError } from "./lib/error.js";
 import { loadConfig } from "./config.js";
 import { runCommand } from "./commands/run.js";
 
@@ -17,7 +18,7 @@ and prepares reply drafts. No local state - always starts fresh.
     loadConfig();
     await runCommand();
   } catch (error: unknown) {
-    console.error("Error:", error instanceof Error ? error.message : String(error));
+    console.error("Error:", formatError(error));
     process.exitCode = 1;
   }
 }

--- a/src/lib/error.ts
+++ b/src/lib/error.ts
@@ -1,0 +1,3 @@
+export function formatError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/src/lib/outlook-compose.test.ts
+++ b/src/lib/outlook-compose.test.ts
@@ -1,0 +1,96 @@
+import { FIXTURES_DIR, setupBrowser } from "../__test__/test-helper.js";
+import { describe, expect, test } from "bun:test";
+
+import type { PdfItem } from "./outlook-dom.js";
+import { prepareDrafts } from "./outlook-compose.js";
+
+describe("prepareDrafts", () => {
+  const { getPage } = setupBrowser();
+
+  test("returns early with empty items array", async () => {
+    // Given
+    const page = getPage();
+    await page.goto(`file://${FIXTURES_DIR}/outlook.html`);
+    const items: PdfItem[] = [];
+
+    // When / Then - should complete without error and not interact with page
+    await prepareDrafts(page, items, {
+      ccEmails: [],
+      replyMessage: "ok pour moi",
+    });
+  }, 30_000);
+
+  test("creates draft reply with message and attachment", async () => {
+    // Given
+    const page = getPage();
+    await page.goto(`file://${FIXTURES_DIR}/outlook.html`);
+    const items: PdfItem[] = [
+      {
+        conversationId: "conv-001",
+        senderLastname: "Dupont",
+        signedPdf: new Uint8Array([1, 2, 3]),
+        subject: "Test Subject",
+      },
+    ];
+
+    // When
+    await prepareDrafts(page, items, {
+      ccEmails: [],
+      replyMessage: "ok pour moi",
+    });
+
+    // Then - email should be moved (no longer in list with conv-001)
+    const emailItem = page.locator('[data-convid="conv-001"]');
+    expect(await emailItem.count()).toBe(0);
+  }, 60_000);
+
+  test("adds CC recipients when provided", async () => {
+    // Given
+    const page = getPage();
+    await page.goto(`file://${FIXTURES_DIR}/outlook.html`);
+    const items: PdfItem[] = [
+      {
+        conversationId: "conv-002",
+        senderLastname: "Martin",
+        signedPdf: new Uint8Array([1, 2, 3]),
+        subject: "Documents fiscaux 2024",
+      },
+    ];
+
+    // When
+    await prepareDrafts(page, items, {
+      ccEmails: ["manager@example.com"],
+      replyMessage: "ok pour moi",
+    });
+
+    // Then - email should be moved
+    const emailItem = page.locator('[data-convid="conv-002"]');
+    expect(await emailItem.count()).toBe(0);
+  }, 60_000);
+
+  test("continues processing when moveToFolder fails for one item", async () => {
+    // Given
+    const page = getPage();
+    await page.goto(`file://${FIXTURES_DIR}/outlook.html`);
+    const items: PdfItem[] = [
+      {
+        conversationId: "nonexistent-conv",
+        senderLastname: "Unknown",
+        signedPdf: new Uint8Array([1, 2, 3]),
+        subject: "Will fail move",
+      },
+      {
+        conversationId: "conv-001",
+        senderLastname: "Dupont",
+        signedPdf: new Uint8Array([1, 2, 3]),
+        subject: "Should succeed",
+      },
+    ];
+
+    // When / Then - should complete without throwing
+    await prepareDrafts(page, items, {
+      ccEmails: [],
+      replyMessage: "ok pour moi",
+    });
+  }, 90_000);
+});

--- a/src/lib/outlook-compose.ts
+++ b/src/lib/outlook-compose.ts
@@ -11,6 +11,7 @@ import {
 import type { Page } from "playwright";
 import type { PdfItem } from "./outlook-dom.js";
 import { createTempRunDir } from "./temp-files.js";
+import { formatError } from "./error.js";
 import { generateAttachmentName } from "./pdf.js";
 import { takeErrorScreenshot } from "../services/browser.js";
 
@@ -41,7 +42,7 @@ export async function prepareDrafts(
       try {
         composeBody = await openReply(page, item.conversationId);
       } catch (error) {
-        console.log(`  -> ${error instanceof Error ? error.message : String(error)}, skipping`);
+        console.log(`  -> ${formatError(error)}, skipping`);
         await takeErrorScreenshot(page, `reply-fail-${idx}`);
         continue;
       }
@@ -51,7 +52,7 @@ export async function prepareDrafts(
         try {
           await addCcRecipients(page, options.ccEmails);
         } catch (error) {
-          console.log(`  -> ${error instanceof Error ? error.message : String(error)}, skipping`);
+          console.log(`  -> ${formatError(error)}, skipping`);
           await takeErrorScreenshot(page, `cc-fail-${idx}`);
           continue;
         }
@@ -64,7 +65,7 @@ export async function prepareDrafts(
       try {
         await attachFile(page, tmpPath);
       } catch (error) {
-        console.log(`  -> ${error instanceof Error ? error.message : String(error)}, skipping`);
+        console.log(`  -> ${formatError(error)}, skipping`);
         await takeErrorScreenshot(page, `attach-fail-${idx}`);
         continue;
       } finally {
@@ -81,7 +82,7 @@ export async function prepareDrafts(
         await moveToFolder(page, item.conversationId, "Inbox");
         console.log(`  -> Done`);
       } catch (error) {
-        console.log(`  -> ${error instanceof Error ? error.message : String(error)}`);
+        console.log(`  -> ${formatError(error)}`);
         await takeErrorScreenshot(page, `move-fail-${idx}`);
       }
     }


### PR DESCRIPTION
## Summary

- **Move try-catch inside inner PDF loop** so remaining PDFs in an email continue processing after one fails
- **Extract `formatError` utility** to eliminate 7x duplication across `index.ts`, `outlook-compose.ts`, and `outlook-dom.ts`
- **Add tests for `outlook-compose.ts`** (4 tests covering drafts creation and error handling paths)
- **Update README.md** with optional environment variables table and JPG/JPEG signature support
- **Replace fixed timeouts with event-driven waits** in `expandThread` (300ms checks vs 1s) and `attachFile` (wait for attachment indicator vs fixed 2s)

## Test plan

- [x] All 103 tests pass
- [x] Linter passes with 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)