### PR TITLE
Migrate unit tests from bun:test to Vitest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
           cache: true
       - run: vp install
       - run: vp check
-      - run: vp run knip
+      - run: vp exec knip
       - run: vp run jscpd
 
   build:
@@ -46,8 +46,11 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2
-      - run: bun install
-      - run: bun test --coverage --coverage-reporter=lcov --reporter=junit --reporter-outfile=./junit.xml
+      - uses: voidzero-dev/setup-vp@v1
+        with:
+          cache: true
+      - run: vp install
+      - run: vp test run --coverage --reporter=junit --outputFile=./junit.xml
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v6
         with:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,11 +7,11 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ```bash
 vp install           # Install dependencies (wraps bun)
 vp run build         # Build extension to ./dist
-vp run lint          # Lint (type-aware)
-vp run fmt           # Format
+vp lint              # Lint (type-aware, config in vite.config.ts)
+vp fmt               # Format
 vp check             # Run fmt + lint + typecheck in one command
-vp run test          # Run unit tests
-vp run test src/shared/pdf.test.ts  # Run a single test file
+vp test              # Run unit tests (via Vitest)
+vp test src/shared/pdf.test.ts  # Run a single test file
 vp run test:e2e      # Run e2e tests with Playwright
 vp run package       # Package extension
 ```

--- a/README.md
+++ b/README.md
@@ -49,9 +49,9 @@ The extension will:
 
 ```bash
 vp run build       # Build to ./dist
-vp run lint        # Type-aware linting
-vp run fmt         # Format code
-vp run test        # Unit tests
+vp lint            # Type-aware linting
+vp fmt             # Format code
+vp test            # Unit tests
 vp run test:e2e    # E2E tests
 ```
 

--- a/bun.lock
+++ b/bun.lock
@@ -8,12 +8,13 @@
         "pdf-lib": "1.17.1",
       },
       "devDependencies": {
-        "@happy-dom/global-registrator": "^20.9.0",
-        "@playwright/test": "^1.59.1",
+        "@playwright/test": "1.59.1",
         "@types/bun": "1.3.12",
-        "@types/chrome": "^0.1.40",
-        "jscpd": "^4.0.9",
-        "knip": "^6.4.1",
+        "@types/chrome": "0.1.40",
+        "@vitest/coverage-v8": "4.1.4",
+        "happy-dom": "20.9.0",
+        "jscpd": "4.0.9",
+        "knip": "6.4.1",
         "vite-plus": "0.1.18",
       },
     },
@@ -27,9 +28,11 @@
 
     "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
 
-    "@babel/parser": ["@babel/parser@7.28.6", "", { "dependencies": { "@babel/types": "^7.28.6" }, "bin": "./bin/babel-parser.js" }, "sha512-TeR9zWR18BvbfPmGbLampPMW+uW1NZnJlRuuHso8i87QZNq2JRF9i6RgxRqtEq+wQGsS19NNTWr2duhnE49mfQ=="],
+    "@babel/parser": ["@babel/parser@7.29.2", "", { "dependencies": { "@babel/types": "^7.29.0" }, "bin": "./bin/babel-parser.js" }, "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA=="],
 
-    "@babel/types": ["@babel/types@7.28.6", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-0ZrskXVEHSWIqZM/sQZ4EV3jZJXRkio/WCxaqKZP1g//CEWEPSfeZFcms4XeKBCHU0ZKnIkdJeU/kF+eRp5lBg=="],
+    "@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
+
+    "@bcoe/v8-coverage": ["@bcoe/v8-coverage@1.0.2", "", {}, "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA=="],
 
     "@colors/colors": ["@colors/colors@1.5.0", "", {}, "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ=="],
 
@@ -39,7 +42,11 @@
 
     "@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.1.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ=="],
 
-    "@happy-dom/global-registrator": ["@happy-dom/global-registrator@20.9.0", "", { "dependencies": { "@types/node": ">=20.0.0", "happy-dom": "^20.9.0" } }, "sha512-lBW6/m5BIFl3pMuWPNN0lIOYw9LMCmPfix53ExS3FBi4E+NELEljQ3xH6aAV9IYiQRfn9YIIgzzMrD0vIcD7tw=="],
+    "@jridgewell/resolve-uri": ["@jridgewell/resolve-uri@3.1.2", "", {}, "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw=="],
+
+    "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
+
+    "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
     "@jscpd/badge-reporter": ["@jscpd/badge-reporter@4.0.5", "", { "dependencies": { "badgen": "^3.2.3", "colors": "^1.4.0", "fs-extra": "^11.2.0" } }, "sha512-SLVhP00R9lkQ//Ivaanfm7k0L9sewpBven670kk1uGec2SWUOa7MVQcuad/TV59KEZ73UIC1lXvi6O9hAnbpUw=="],
 
@@ -251,6 +258,8 @@
 
     "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
 
+    "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
+
     "@types/filesystem": ["@types/filesystem@0.0.36", "", { "dependencies": { "@types/filewriter": "*" } }, "sha512-vPDXOZuannb9FZdxgHnqSwAG/jvdGM8Wq+6N4D/d80z+D4HWH+bItqsZaVRQykAn6WEVeEkLm2oQigyHtgb0RA=="],
 
     "@types/filewriter": ["@types/filewriter@0.0.33", "", {}, "sha512-xFU8ZXTw4gd358lb2jw25nxY9QAgqn2+bKKjKOYfNCzN4DKCFetK7sPtrlpg66Ywe3vWY9FNxprZawAh9wfJ3g=="],
@@ -264,6 +273,12 @@
     "@types/whatwg-mimetype": ["@types/whatwg-mimetype@3.0.2", "", {}, "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA=="],
 
     "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
+
+    "@vitest/coverage-v8": ["@vitest/coverage-v8@4.1.4", "", { "dependencies": { "@bcoe/v8-coverage": "^1.0.2", "@vitest/utils": "4.1.4", "ast-v8-to-istanbul": "^1.0.0", "istanbul-lib-coverage": "^3.2.2", "istanbul-lib-report": "^3.0.1", "istanbul-reports": "^3.2.0", "magicast": "^0.5.2", "obug": "^2.1.1", "std-env": "^4.0.0-rc.1", "tinyrainbow": "^3.1.0" }, "peerDependencies": { "@vitest/browser": "4.1.4", "vitest": "4.1.4" }, "optionalPeers": ["@vitest/browser"] }, "sha512-x7FptB5oDruxNPDNY2+S8tCh0pcq7ymCe1gTHcsp733jYjrJl8V1gMUlVysuCD9Kz46Xz9t1akkv08dPcYDs1w=="],
+
+    "@vitest/pretty-format": ["@vitest/pretty-format@4.1.4", "", { "dependencies": { "tinyrainbow": "^3.1.0" } }, "sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A=="],
+
+    "@vitest/utils": ["@vitest/utils@4.1.4", "", { "dependencies": { "@vitest/pretty-format": "4.1.4", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw=="],
 
     "@voidzero-dev/vite-plus-core": ["@voidzero-dev/vite-plus-core@0.1.18", "", { "dependencies": { "@oxc-project/runtime": "=0.124.0", "@oxc-project/types": "=0.124.0", "lightningcss": "^1.30.2", "postcss": "^8.5.6" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@arethetypeswrong/core": "^0.18.1", "@tsdown/css": "0.21.8", "@tsdown/exe": "0.21.8", "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "publint": "^0.3.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "typescript": "^5.0.0 || ^6.0.0", "unplugin-unused": "^0.5.0", "yaml": "^2.4.2" }, "optionalPeers": ["@arethetypeswrong/core", "@tsdown/css", "@tsdown/exe", "@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "publint", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "typescript", "unplugin-unused", "yaml"] }, "sha512-3PmXOL26yHzlw8ET9SwXCmglGzUYq2fOTYf2t0mxvVIs7ua3bnf6tOnmR+6YX5k1Ez26B0ooYzx+znc8k+CAMw=="],
 
@@ -295,6 +310,8 @@
 
     "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
 
+    "ast-v8-to-istanbul": ["ast-v8-to-istanbul@1.0.0", "", { "dependencies": { "@jridgewell/trace-mapping": "^0.3.31", "estree-walker": "^3.0.3", "js-tokens": "^10.0.0" } }, "sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg=="],
+
     "babel-walk": ["babel-walk@3.0.0-canary-5", "", { "dependencies": { "@babel/types": "^7.9.6" } }, "sha512-GAwkz0AihzY5bkwIY5QDR+LvsRQgB/B+1foMPvi0FZPMl5fjD7ICiznUiBdLYMH1QYe6vqu4gWYytZOccLouFw=="],
 
     "badgen": ["badgen@3.2.3", "", {}, "sha512-svDuwkc63E/z0ky3drpUppB83s/nlgDciH9m+STwwQoWyq7yCgew1qEfJ+9axkKdNq7MskByptWUN9j1PGMwFA=="],
@@ -321,6 +338,8 @@
 
     "constantinople": ["constantinople@4.0.1", "", { "dependencies": { "@babel/parser": "^7.6.0", "@babel/types": "^7.6.1" } }, "sha512-vCrqcSIq4//Gx74TXXCGnHpulY1dskqLTFGDmhrGxzeXL8lF8kvXv6mpNWlJj1uD4DW23D4ljAqbY4RRaaUZIw=="],
 
+    "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
+
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
@@ -342,6 +361,8 @@
     "es-module-lexer": ["es-module-lexer@1.7.0", "", {}, "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA=="],
 
     "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
+
+    "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
 
     "eventemitter3": ["eventemitter3@5.0.4", "", {}, "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="],
 
@@ -381,11 +402,15 @@
 
     "happy-dom": ["happy-dom@20.9.0", "", { "dependencies": { "@types/node": ">=20.0.0", "@types/whatwg-mimetype": "^3.0.2", "@types/ws": "^8.18.1", "entities": "^7.0.1", "whatwg-mimetype": "^3.0.0", "ws": "^8.18.3" } }, "sha512-GZZ9mKe8r646NUAf/zemnGbjYh4Bt8/MqASJY+pSm5ZDtc3YQox+4gsLI7yi1hba6o+eCsGxpHn5+iEVn31/FQ=="],
 
+    "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
+
     "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
 
     "has-tostringtag": ["has-tostringtag@1.0.2", "", { "dependencies": { "has-symbols": "^1.0.3" } }, "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw=="],
 
     "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
+
+    "html-escaper": ["html-escaper@2.0.2", "", {}, "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg=="],
 
     "human-signals": ["human-signals@1.1.1", "", {}, "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw=="],
 
@@ -409,9 +434,17 @@
 
     "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
+    "istanbul-lib-coverage": ["istanbul-lib-coverage@3.2.2", "", {}, "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg=="],
+
+    "istanbul-lib-report": ["istanbul-lib-report@3.0.1", "", { "dependencies": { "istanbul-lib-coverage": "^3.0.0", "make-dir": "^4.0.0", "supports-color": "^7.1.0" } }, "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw=="],
+
+    "istanbul-reports": ["istanbul-reports@3.2.0", "", { "dependencies": { "html-escaper": "^2.0.0", "istanbul-lib-report": "^3.0.0" } }, "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA=="],
+
     "jiti": ["jiti@2.6.1", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ=="],
 
     "js-stringify": ["js-stringify@1.0.2", "", {}, "sha512-rtS5ATOo2Q5k1G+DADISilDA6lv79zIiwFd6CcjuIxGKLFm5C+RLImRscVap9k55i+MOZwgliw+NejvkLuGD5g=="],
+
+    "js-tokens": ["js-tokens@10.0.0", "", {}, "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q=="],
 
     "jscpd": ["jscpd@4.0.9", "", { "dependencies": { "@jscpd/badge-reporter": "4.0.5", "@jscpd/core": "4.0.5", "@jscpd/finder": "4.0.5", "@jscpd/html-reporter": "4.0.5", "@jscpd/tokenizer": "4.0.5", "colors": "^1.4.0", "commander": "^5.0.0", "fs-extra": "^11.2.0", "jscpd-sarif-reporter": "4.0.7" }, "bin": { "jscpd": "bin/jscpd" } }, "sha512-fp6Sh42W3mIPoQgZmgYmKDLQzEDnnX2vaGlTN4haILkB2vsi+ewcCHEtWR/2CR/QbsBvAvsNo8U5Sa+p9aHiGw=="],
 
@@ -446,6 +479,10 @@
     "lightningcss-win32-arm64-msvc": ["lightningcss-win32-arm64-msvc@1.32.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw=="],
 
     "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.32.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q=="],
+
+    "magicast": ["magicast@0.5.2", "", { "dependencies": { "@babel/parser": "^7.29.0", "@babel/types": "^7.29.0", "source-map-js": "^1.2.1" } }, "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ=="],
+
+    "make-dir": ["make-dir@4.0.0", "", { "dependencies": { "semver": "^7.5.3" } }, "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw=="],
 
     "markdown-table": ["markdown-table@2.0.0", "", { "dependencies": { "repeat-string": "^1.0.0" } }, "sha512-Ezda85ToJUBhM6WGaG6veasyym+Tbs3cMAw/ZhOPqXiYsr0jgocBV3j3nx+4lk47plLlIqjwuTm/ywVI+zjJ/A=="],
 
@@ -551,6 +588,8 @@
 
     "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
 
+    "semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
     "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
 
     "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
@@ -575,6 +614,8 @@
 
     "strip-json-comments": ["strip-json-comments@5.0.3", "", {}, "sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw=="],
 
+    "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
+
     "supports-preserve-symlinks-flag": ["supports-preserve-symlinks-flag@1.0.0", "", {}, "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="],
 
     "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
@@ -584,6 +625,8 @@
     "tinyglobby": ["tinyglobby@0.2.16", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg=="],
 
     "tinypool": ["tinypool@2.1.0", "", {}, "sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw=="],
+
+    "tinyrainbow": ["tinyrainbow@3.1.0", "", {}, "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw=="],
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
 
@@ -602,6 +645,8 @@
     "vite": ["@voidzero-dev/vite-plus-core@0.1.18", "", { "dependencies": { "@oxc-project/runtime": "=0.124.0", "@oxc-project/types": "=0.124.0", "lightningcss": "^1.30.2", "postcss": "^8.5.6" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@arethetypeswrong/core": "^0.18.1", "@tsdown/css": "0.21.8", "@tsdown/exe": "0.21.8", "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "publint": "^0.3.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "typescript": "^5.0.0 || ^6.0.0", "unplugin-unused": "^0.5.0", "yaml": "^2.4.2" }, "optionalPeers": ["@arethetypeswrong/core", "@tsdown/css", "@tsdown/exe", "@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "publint", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "typescript", "unplugin-unused", "yaml"] }, "sha512-3PmXOL26yHzlw8ET9SwXCmglGzUYq2fOTYf2t0mxvVIs7ua3bnf6tOnmR+6YX5k1Ez26B0ooYzx+znc8k+CAMw=="],
 
     "vite-plus": ["vite-plus@0.1.18", "", { "dependencies": { "@oxc-project/types": "=0.124.0", "@voidzero-dev/vite-plus-core": "0.1.18", "@voidzero-dev/vite-plus-test": "0.1.18", "oxfmt": "=0.45.0", "oxlint": "=1.60.0", "oxlint-tsgolint": "=0.20.0" }, "optionalDependencies": { "@voidzero-dev/vite-plus-darwin-arm64": "0.1.18", "@voidzero-dev/vite-plus-darwin-x64": "0.1.18", "@voidzero-dev/vite-plus-linux-arm64-gnu": "0.1.18", "@voidzero-dev/vite-plus-linux-arm64-musl": "0.1.18", "@voidzero-dev/vite-plus-linux-x64-gnu": "0.1.18", "@voidzero-dev/vite-plus-linux-x64-musl": "0.1.18", "@voidzero-dev/vite-plus-win32-arm64-msvc": "0.1.18", "@voidzero-dev/vite-plus-win32-x64-msvc": "0.1.18" }, "bin": { "vp": "bin/vp", "oxfmt": "bin/oxfmt", "oxlint": "bin/oxlint" } }, "sha512-RiWUoOmQiJMtd4Dfm6WD0v0Selqh/nQzmaGVIrkfnr+2s5UxGVZy7n2TCO5ZnR7w9noMIgtUAQN8GtKhwHEiOQ=="],
+
+    "vitest": ["@voidzero-dev/vite-plus-test@0.1.18", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@voidzero-dev/vite-plus-core": "0.1.18", "es-module-lexer": "^1.7.0", "obug": "^2.1.1", "pixelmatch": "^7.1.0", "pngjs": "^7.0.0", "sirv": "^3.0.2", "std-env": "^4.0.0", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "ws": "^8.18.3" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/coverage-istanbul": "4.1.4", "@vitest/coverage-v8": "4.1.4", "@vitest/ui": "4.1.4", "happy-dom": "*", "jsdom": "*", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"] }, "sha512-dovC2kJgiwMI8ay0i+3NvQGCDWPj8HQB2ONP/HbdJ5/XQVPq13+BihnCq8/ztz6uGhiDD8Nu4OZ3RgB14uvTfA=="],
 
     "void-elements": ["void-elements@3.1.0", "", {}, "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w=="],
 
@@ -631,6 +676,12 @@
 
     "@voidzero-dev/vite-plus-core/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
+    "babel-walk/@babel/types": ["@babel/types@7.28.6", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-0ZrskXVEHSWIqZM/sQZ4EV3jZJXRkio/WCxaqKZP1g//CEWEPSfeZFcms4XeKBCHU0ZKnIkdJeU/kF+eRp5lBg=="],
+
+    "constantinople/@babel/parser": ["@babel/parser@7.28.6", "", { "dependencies": { "@babel/types": "^7.28.6" }, "bin": "./bin/babel-parser.js" }, "sha512-TeR9zWR18BvbfPmGbLampPMW+uW1NZnJlRuuHso8i87QZNq2JRF9i6RgxRqtEq+wQGsS19NNTWr2duhnE49mfQ=="],
+
+    "constantinople/@babel/types": ["@babel/types@7.28.6", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-0ZrskXVEHSWIqZM/sQZ4EV3jZJXRkio/WCxaqKZP1g//CEWEPSfeZFcms4XeKBCHU0ZKnIkdJeU/kF+eRp5lBg=="],
+
     "micromatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
     "oxc-parser/@oxc-project/types": ["@oxc-project/types@0.121.0", "", {}, "sha512-CGtOARQb9tyv7ECgdAlFxi0Fv7lmzvmlm2rpD/RdijOO9rfk/JvB1CjT8EnoD+tjna/IYgKKw3IV7objRb+aYw=="],
@@ -638,5 +689,9 @@
     "tinyglobby/picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
 
     "vite/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "with/@babel/parser": ["@babel/parser@7.28.6", "", { "dependencies": { "@babel/types": "^7.28.6" }, "bin": "./bin/babel-parser.js" }, "sha512-TeR9zWR18BvbfPmGbLampPMW+uW1NZnJlRuuHso8i87QZNq2JRF9i6RgxRqtEq+wQGsS19NNTWr2duhnE49mfQ=="],
+
+    "with/@babel/types": ["@babel/types@7.28.6", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-0ZrskXVEHSWIqZM/sQZ4EV3jZJXRkio/WCxaqKZP1g//CEWEPSfeZFcms4XeKBCHU0ZKnIkdJeU/kF+eRp5lBg=="],
   }
 }

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,4 +1,0 @@
-[test]
-root = "src"
-coverageSkipTestFiles = true
-

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -9,10 +9,11 @@ export default {
     "src/popup/popup.ts",
     "scripts/*.ts",
     "e2e/tests/**/*.ts",
+    "src/**/*.test.ts",
     "vite.config.ts",
   ],
 
-  ignoreDependencies: ["@types/chrome"],
+  ignoreDependencies: ["@types/chrome", "@vitest/coverage-v8", "happy-dom"],
   ignoreExportsUsedInFile: true,
   rules: {
     exports: "off",

--- a/package.json
+++ b/package.json
@@ -6,12 +6,8 @@
   "scripts": {
     "build": "bun run build.ts",
     "package": "bun run scripts/package.ts",
-    "fmt": "vp fmt",
-    "lint": "vp lint --type-aware --type-check",
-    "test": "bun test",
     "test:e2e": "playwright test --config e2e/playwright.config.ts",
     "test:e2e:ui": "playwright test --config e2e/playwright.config.ts --ui",
-    "knip": "knip",
     "jscpd": "jscpd src/ --min-lines 10 --min-tokens 100",
     "prepare": "vp config"
   },
@@ -19,12 +15,13 @@
     "pdf-lib": "1.17.1"
   },
   "devDependencies": {
-    "@happy-dom/global-registrator": "^20.9.0",
-    "@playwright/test": "^1.59.1",
+    "@playwright/test": "1.59.1",
     "@types/bun": "1.3.12",
-    "@types/chrome": "^0.1.40",
-    "jscpd": "^4.0.9",
-    "knip": "^6.4.1",
+    "@types/chrome": "0.1.40",
+    "@vitest/coverage-v8": "4.1.4",
+    "happy-dom": "20.9.0",
+    "jscpd": "4.0.9",
+    "knip": "6.4.1",
     "vite-plus": "0.1.18"
   },
   "overrides": {

--- a/src/background/service-worker.test.ts
+++ b/src/background/service-worker.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable unicorn/no-null */
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { beforeEach, describe, expect, test, vi } from "vite-plus/test";
 
 import { type SignPdfRequest } from "#shared/messages.js";
 
@@ -18,10 +18,10 @@ const mockLocalData: {
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- Partial chrome mock for testing
 (globalThis as Record<string, unknown>).chrome = {
-  runtime: { onMessage: { addListener: mock() } },
+  runtime: { onMessage: { addListener: vi.fn() } },
   storage: {
-    local: { get: mock(async () => mockLocalData) },
-    sync: { get: mock(async () => mockSyncData) },
+    local: { get: vi.fn(async () => mockLocalData) },
+    sync: { get: vi.fn(async () => mockSyncData) },
   },
 };
 

--- a/src/build.test.ts
+++ b/src/build.test.ts
@@ -1,7 +1,8 @@
 /* eslint-disable import/no-nodejs-modules -- Build tests need filesystem access */
-import { describe, expect, test } from "bun:test";
 import { existsSync } from "node:fs";
-import { readdir } from "node:fs/promises";
+import { readFile, readdir } from "node:fs/promises";
+
+import { describe, expect, test } from "vite-plus/test";
 
 const SRC_DIR = "./src";
 const DIST_DIR = "./dist";
@@ -15,8 +16,8 @@ describe("source HTML", () => {
     ];
 
     for (const { html, ts } of pages) {
-      const htmlContent = await Bun.file(`${SRC_DIR}/${html}`).text();
-      const tsContent = await Bun.file(`${SRC_DIR}/${ts}`).text();
+      const htmlContent = await readFile(`${SRC_DIR}/${html}`, "utf8");
+      const tsContent = await readFile(`${SRC_DIR}/${ts}`, "utf8");
       const hasExport = /^export /m.test(tsContent);
 
       if (hasExport) {
@@ -37,7 +38,7 @@ describe.skipIf(!distExists)("build output", () => {
     ];
 
     for (const path of entrypoints) {
-      const js = await Bun.file(`${DIST_DIR}/${path}`).text();
+      const js = await readFile(`${DIST_DIR}/${path}`, "utf8");
       expect(js.length).toBeGreaterThan(0);
     }
   });

--- a/src/content/happy-dom.setup.ts
+++ b/src/content/happy-dom.setup.ts
@@ -1,3 +1,0 @@
-import { GlobalRegistrator } from "@happy-dom/global-registrator";
-
-GlobalRegistrator.register();

--- a/src/content/main-world.test.ts
+++ b/src/content/main-world.test.ts
@@ -1,7 +1,6 @@
 /// <reference lib="dom" />
-/* eslint-disable unicorn/no-null, unicorn/prefer-global-this, import/no-unassigned-import, promise/avoid-new -- DOM test fixtures with window API */
-import "./happy-dom.setup.js";
-import { afterEach, beforeAll, describe, expect, test } from "bun:test";
+/* eslint-disable unicorn/no-null, unicorn/prefer-global-this, promise/avoid-new -- DOM test fixtures with window API */
+import { afterEach, beforeAll, describe, expect, test } from "vite-plus/test";
 
 import {
   type BlobCapturedMessage,

--- a/src/content/outlook-actions.test.ts
+++ b/src/content/outlook-actions.test.ts
@@ -1,7 +1,6 @@
 /// <reference lib="dom" />
-/* eslint-disable unicorn/no-null, @typescript-eslint/no-non-null-assertion, import/no-unassigned-import -- DOM test fixtures */
-import "./happy-dom.setup.js";
-import { afterEach, describe, expect, test } from "bun:test";
+/* eslint-disable unicorn/no-null, @typescript-eslint/no-non-null-assertion -- DOM test fixtures */
+import { afterEach, describe, expect, test } from "vite-plus/test";
 
 import {
   expandMessage,

--- a/src/content/outlook-automation.test.ts
+++ b/src/content/outlook-automation.test.ts
@@ -1,7 +1,6 @@
 /// <reference lib="dom" />
-/* eslint-disable unicorn/no-null, @typescript-eslint/no-non-null-assertion, import/no-unassigned-import -- DOM test fixtures */
-import "./happy-dom.setup.js";
-import { afterEach, describe, expect, test } from "bun:test";
+/* eslint-disable unicorn/no-null, @typescript-eslint/no-non-null-assertion -- DOM test fixtures */
+import { afterEach, describe, expect, test } from "vite-plus/test";
 
 import { findButtonByName, findByRole } from "./outlook-automation.js";
 

--- a/src/content/outlook-compose-actions.test.ts
+++ b/src/content/outlook-compose-actions.test.ts
@@ -1,7 +1,6 @@
 /// <reference lib="dom" />
-/* eslint-disable unicorn/no-null, @typescript-eslint/no-non-null-assertion, import/no-unassigned-import -- DOM test fixtures */
-import "./happy-dom.setup.js";
-import { afterEach, describe, expect, test } from "bun:test";
+/* eslint-disable unicorn/no-null, @typescript-eslint/no-non-null-assertion -- DOM test fixtures */
+import { afterEach, describe, expect, test } from "vite-plus/test";
 
 import {
   attachFile,

--- a/src/content/outlook-compose.test.ts
+++ b/src/content/outlook-compose.test.ts
@@ -1,7 +1,6 @@
 /// <reference lib="dom" />
-/* eslint-disable unicorn/no-null, import/no-unassigned-import -- DOM test fixtures */
-import "./happy-dom.setup.js";
-import { afterEach, describe, expect, test } from "bun:test";
+/* eslint-disable unicorn/no-null -- DOM test fixtures */
+import { afterEach, describe, expect, test } from "vite-plus/test";
 
 import { type DraftResult, prepareDrafts } from "./outlook-compose.js";
 

--- a/src/content/outlook-dom.test.ts
+++ b/src/content/outlook-dom.test.ts
@@ -1,7 +1,6 @@
 /// <reference lib="dom" />
-/* eslint-disable unicorn/no-null, import/no-unassigned-import -- DOM test fixtures */
-import "./happy-dom.setup.js";
-import { afterEach, describe, expect, test } from "bun:test";
+/* eslint-disable unicorn/no-null -- DOM test fixtures */
+import { afterEach, describe, expect, test } from "vite-plus/test";
 
 // The helper getConversationContext is not exported, so test collectPdfAttachments indirectly
 // By verifying the DOM parsing logic through the public API

--- a/src/content/outlook-download.test.ts
+++ b/src/content/outlook-download.test.ts
@@ -1,7 +1,6 @@
 /// <reference lib="dom" />
-/* eslint-disable unicorn/no-null, import/no-unassigned-import -- DOM test fixtures */
-import "./happy-dom.setup.js";
-import { afterEach, describe, expect, test } from "bun:test";
+/* eslint-disable unicorn/no-null -- DOM test fixtures */
+import { afterEach, describe, expect, test } from "vite-plus/test";
 
 // Verify downloadAttachment contract through its error paths
 // Type guards and blob protocol are internal
@@ -21,6 +20,6 @@ describe("outlook-download module", () => {
     const { downloadAttachment } = await import("./outlook-download.js");
 
     // When/Then: throws because waitUntilAttachmentReady times out
-    expect(downloadAttachment(option)).rejects.toThrow("Attachment ID not found in URL");
+    await expect(downloadAttachment(option)).rejects.toThrow("Attachment ID not found in URL");
   });
 });

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable unicorn/no-null -- Chrome mock setup */
-import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, beforeEach, describe, expect, test, vi } from "vite-plus/test";
 
 import {
   type ContentToBackgroundMessage,
@@ -17,10 +17,13 @@ type MessageListener<TMessage, TResponse> = (
   sendResponse: (response: TResponse) => void,
 ) => boolean;
 
-function captureResponse<T>(): { mock: ReturnType<typeof mock>; promise: Promise<T> } {
+function captureResponse<T>(): {
+  mock: (response: T) => void;
+  promise: Promise<T>;
+} {
   const { promise, resolve } = Promise.withResolvers<T>();
   return {
-    mock: mock((response: T) => {
+    mock: vi.fn<(response: T) => void>((response: T) => {
       resolve(response);
     }),
     promise,
@@ -29,14 +32,14 @@ function captureResponse<T>(): { mock: ReturnType<typeof mock>; promise: Promise
 
 // --- Service worker handler capture ---
 
-const swAddListenerMock = mock();
+const swAddListenerMock = vi.fn();
 // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- Partial chrome mock for testing
 (globalThis as Record<string, unknown>).chrome = {
   runtime: { onMessage: { addListener: swAddListenerMock } },
   storage: {
-    local: { get: mock(async () => ({ signatureImage: null })) },
+    local: { get: vi.fn(async () => ({ signatureImage: null })) },
     sync: {
-      get: mock(async () => ({
+      get: vi.fn(async () => ({
         myEmail: "test@example.com",
         replyMessage: "Ok",
         signaturePosition: { height: 50, width: 150, x: 100, y: 100 },
@@ -55,24 +58,27 @@ const swHandler = swAddListenerMock.mock.calls[0]![0] as MessageListener<
 
 // --- Content handler capture ---
 
-await mock.module("./content/outlook-dom.js", () => ({
-  collectPdfAttachments: mock(() => Promise.resolve([])),
+vi.mock("./content/outlook-dom.js", () => ({
+  collectPdfAttachments: async (): Promise<never[]> => [],
 }));
-await mock.module("./content/outlook-compose.js", () => ({
-  prepareDrafts: mock(() => Promise.resolve({ errors: [], successCount: 0 })),
+vi.mock("./content/outlook-compose.js", () => ({
+  prepareDrafts: async (): Promise<{ errors: never[]; successCount: number }> => ({
+    errors: [],
+    successCount: 0,
+  }),
 }));
 
-const contentAddListenerMock = mock();
+const contentAddListenerMock = vi.fn();
 // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- Partial chrome mock for testing
 (globalThis as Record<string, unknown>).chrome = {
   runtime: {
     id: "test-extension-id",
     onMessage: { addListener: contentAddListenerMock },
-    sendMessage: mock(async () => ({ error: "No signature", success: false })),
+    sendMessage: vi.fn(async () => ({ error: "No signature", success: false })),
   },
   storage: {
     sync: {
-      get: mock(async () => ({
+      get: vi.fn(async () => ({
         myEmail: "test@example.com",
         replyMessage: "Ok",
       })),
@@ -83,7 +89,7 @@ const contentAddListenerMock = mock();
 const originalDocument = globalThis.document;
 // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- Stub document for module load
 globalThis.document = {
-  addEventListener: mock(),
+  addEventListener: vi.fn(),
   documentElement: { dataset: {} },
 } as unknown as typeof globalThis.document;
 await import("./content/content.js");
@@ -118,11 +124,11 @@ describe("service-worker onMessage handler", () => {
   beforeEach(() => {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- Partial chrome mock for testing
     (globalThis as Record<string, unknown>).chrome = {
-      runtime: { onMessage: { addListener: mock() } },
+      runtime: { onMessage: { addListener: vi.fn() } },
       storage: {
-        local: { get: mock(async () => ({ signatureImage: null })) },
+        local: { get: vi.fn(async () => ({ signatureImage: null })) },
         sync: {
-          get: mock(async () => ({
+          get: vi.fn(async () => ({
             myEmail: "test@example.com",
             replyMessage: "Ok",
             signaturePosition: { height: 50, width: 150, x: 100, y: 100 },
@@ -133,7 +139,7 @@ describe("service-worker onMessage handler", () => {
   });
 
   test("rejects messages from non-Outlook origins", () => {
-    const sendResponse = mock();
+    const sendResponse = vi.fn();
 
     const keepOpen = swHandler(validMessage, { url: "https://evil.com/mail/inbox" }, sendResponse);
 
@@ -141,7 +147,7 @@ describe("service-worker onMessage handler", () => {
   });
 
   test("rejects messages with undefined sender URL", () => {
-    const sendResponse = mock();
+    const sendResponse = vi.fn();
 
     const keepOpen = swHandler(validMessage, {}, sendResponse);
 
@@ -149,7 +155,7 @@ describe("service-worker onMessage handler", () => {
   });
 
   test("rejects messages with malformed sender URL", () => {
-    const sendResponse = mock();
+    const sendResponse = vi.fn();
 
     const keepOpen = swHandler(validMessage, { url: "not-a-url" }, sendResponse);
 
@@ -185,12 +191,12 @@ describe("content.ts onMessage handler", () => {
     (globalThis as Record<string, unknown>).chrome = {
       runtime: {
         id: "test-extension-id",
-        onMessage: { addListener: mock() },
-        sendMessage: mock(async () => ({ error: "No signature", success: false })),
+        onMessage: { addListener: vi.fn() },
+        sendMessage: vi.fn(async () => ({ error: "No signature", success: false })),
       },
       storage: {
         sync: {
-          get: mock(async () => ({
+          get: vi.fn(async () => ({
             myEmail: "test@example.com",
             replyMessage: "Ok",
           })),
@@ -200,7 +206,7 @@ describe("content.ts onMessage handler", () => {
   });
 
   test("rejects messages from different extension", () => {
-    const sendResponse = mock();
+    const sendResponse = vi.fn();
 
     const keepOpen = contentHandler(validMessage, { id: "other-extension" }, sendResponse);
 

--- a/src/options/options.test.ts
+++ b/src/options/options.test.ts
@@ -1,11 +1,9 @@
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vite-plus/test";
 
 /* eslint-disable unicorn/no-null -- DOM test fixtures + Chrome mock setup */
 import { getElement } from "#shared/dom.js";
 
-import "../content/happy-dom.setup.js"; // eslint-disable-line import/no-unassigned-import, import/no-relative-parent-imports -- DOM test setup
-
-const syncSetMock = mock(
+const syncSetMock = vi.fn(
   (_data: Readonly<Record<string, unknown>>): Promise<void> => Promise.resolve(),
 );
 
@@ -28,7 +26,7 @@ function setupChromeMock(): void {
       local: {
         get: (defaults: Readonly<Record<string, unknown>>): Promise<Record<string, unknown>> =>
           Promise.resolve({ ...defaults, ...localData }),
-        set: mock((): Promise<void> => Promise.resolve()),
+        set: vi.fn((): Promise<void> => Promise.resolve()),
       },
       sync: {
         get: (defaults: Readonly<Record<string, unknown>>): Promise<Record<string, unknown>> =>

--- a/src/popup/popup.test.ts
+++ b/src/popup/popup.test.ts
@@ -1,10 +1,9 @@
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vite-plus/test";
 
 /* eslint-disable unicorn/no-null -- Chrome mock setup */
-import "../content/happy-dom.setup.js"; // eslint-disable-line import/no-unassigned-import, import/no-relative-parent-imports -- DOM test setup
 
-const tabsQueryMock = mock(() => Promise.resolve([] as chrome.tabs.Tab[]));
-const tabsSendMessageMock = mock(() =>
+const tabsQueryMock = vi.fn(() => Promise.resolve([] as chrome.tabs.Tab[]));
+const tabsSendMessageMock = vi.fn(() =>
   Promise.resolve({ message: "Processed 1/1 emails", success: true }),
 );
 
@@ -13,7 +12,7 @@ function setupChromeMock(): void {
   (globalThis as { chrome: unknown }).chrome = {
     runtime: {
       id: "test-extension-id",
-      openOptionsPage: mock(() => Promise.resolve()),
+      openOptionsPage: vi.fn(() => Promise.resolve()),
     },
     storage: {
       local: {

--- a/src/shared/dom.test.ts
+++ b/src/shared/dom.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "vite-plus/test";
 
 import { getElement } from "./dom.js";
 

--- a/src/shared/encoding.test.ts
+++ b/src/shared/encoding.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, test } from "vite-plus/test";
 
 import { base64ToUint8Array, uint8ArrayToBase64 } from "./encoding.js";
 

--- a/src/shared/errors.test.ts
+++ b/src/shared/errors.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, test } from "vite-plus/test";
 
 import { getErrorMessage } from "./errors.js";
 

--- a/src/shared/pdf.test.ts
+++ b/src/shared/pdf.test.ts
@@ -1,6 +1,5 @@
-import { describe, expect, test } from "bun:test";
-
 import { PDFDocument } from "pdf-lib";
+import { describe, expect, test } from "vite-plus/test";
 
 import {
   generateAttachmentName,

--- a/src/shared/storage.test.ts
+++ b/src/shared/storage.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable unicorn/no-null -- Chrome storage API uses null */
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "vite-plus/test";
 
 function createStorageMock(): unknown {
   const syncData: Record<string, unknown> = {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,15 @@
+import { fileURLToPath } from "node:url";
+
 import { defineConfig } from "vite-plus";
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      "#shared": fileURLToPath(new URL("src/shared", import.meta.url)),
+      "#mocks": fileURLToPath(new URL("e2e/mocks", import.meta.url)),
+      "#helpers": fileURLToPath(new URL("e2e/helpers", import.meta.url)),
+    },
+  },
   lint: {
     options: { typeAware: true, typeCheck: true },
     categories: {
@@ -34,7 +43,6 @@ export default defineConfig({
       },
       {
         files: ["**/*.test.ts"],
-        globals: { Bun: "readonly" },
         rules: {
           "import/no-nodejs-modules": "off",
         },
@@ -45,6 +53,7 @@ export default defineConfig({
         globals: { chrome: "off" },
         rules: {
           "import/no-default-export": "off",
+          "import/no-nodejs-modules": "off",
         },
       },
     ],
@@ -128,5 +137,14 @@ export default defineConfig({
   },
   staged: {
     "*": "vp check --fix",
+  },
+  test: {
+    include: ["src/**/*.test.ts"],
+    environment: "happy-dom",
+    coverage: {
+      provider: "v8",
+      reporter: ["lcov"],
+      exclude: ["**/*.test.ts", "e2e/**", "dist/**", "scripts/**", "build.ts"],
+    },
   },
 });


### PR DESCRIPTION
## Summary

Follow-up to #174. All 17 unit-test files move from \`bun:test\` to Vitest via \`vp test\`.

- \`bun:test\` → \`vite-plus/test\` imports (17 files); \`mock\`/\`mock.module\` → \`vi.fn\`/\`vi.mock\`.
- \`vite.config.ts\` gets a \`test\` block (\`happy-dom\` environment, \`include\`, coverage) plus a \`resolve.alias\` mirror of \`tsconfig.json\`'s \`#shared\`/\`#mocks\`/\`#helpers\` (Vite doesn't read tsconfig paths).
- \`@happy-dom/global-registrator\` → \`happy-dom\`; \`@vitest/coverage-v8\` added.
- Delete \`src/content/happy-dom.setup.ts\` and its 9 per-file imports (the environment config replaces them).
- Delete \`bunfig.toml\` — its \`[test]\` settings moved to \`vite.config.ts\`.
- \`build.test.ts\`: \`Bun.file\` → \`node:fs/promises\` \`readFile\`.
- \`integration.test.ts\`: \`vi.mock\` factories use plain async functions (the factory body can't access \`vi\` due to hoisting); \`captureResponse\` helper typed with a concrete function signature.
- \`outlook-download.test.ts\`: \`await\` the \`expect(...).rejects.toThrow(...)\` promise.
- Remove pure-passthrough scripts (\`test\`, \`fmt\`, \`lint\`, \`knip\`) from \`package.json\`; docs point at \`vp test\` / \`vp lint\` / \`vp fmt\` / \`vp exec knip\` directly (vite-plus-native pattern).
- Pin all previously caret-ranged deps to exact versions (dependabot manages bumps).
- CI \`test\` job: \`setup-bun\` + \`setup-vp\` + \`vp test run --coverage --reporter=junit --outputFile=./junit.xml\`.

## Test plan

- [x] \`vp check\` — 77 files formatted, 51 lint/type-clean
- [x] \`vp test run\` — 92/92 pass (matches bun-test baseline)
- [x] \`vp test run --coverage --reporter=junit --outputFile=./junit.xml\` — generates \`coverage/lcov.info\` and \`junit.xml\`
- [x] \`vp run build\` — dist populated
- [x] \`vp exec knip\` — clean
- [x] CI green on this PR