### PR TITLE
Desloppify: subjective review fixes (target 97)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,8 +48,9 @@ src/
     ├── errors.ts      # Error message extraction
     ├── messages.ts    # Message types
     ├── origins.ts     # Outlook origin constants
-    ├── pdf.ts         # PDF signing, name extraction, attachment naming
+    ├── pdf.ts         # Target month/year extraction, attachment naming, signature format detection
     ├── sender.ts      # Email/lastname extraction from sender strings
+    ├── signer.ts      # PDF signing via pdf-lib (signPdf)
     └── storage.ts     # Chrome storage API wrappers
 ```
 
@@ -57,7 +58,7 @@ src/
 
 The extension uses two content scripts injected into Outlook pages:
 
-- **MAIN world** (`main-world.ts`): Runs in the page's JS context to intercept `blob:` URLs via `XMLHttpRequest` monkey-patching. Communicates PDF data to the content script via `window.postMessage`.
+- **MAIN world** (`main-world.ts`): Runs in the page's JS context to intercept `blob:` URLs by overriding `URL.createObjectURL` and capturing `application/pdf` Blobs. Communicates PDF data to the content script via `window.postMessage`.
 - **ISOLATED world** (`content.ts`): Standard content script that orchestrates the workflow, manipulates DOM, and communicates with the service worker via `chrome.runtime`.
 
 The blob protocol (`blob-protocol.ts`) defines the message types exchanged between worlds.

--- a/build.ts
+++ b/build.ts
@@ -11,7 +11,7 @@ const ENTRIES = [
   "popup/popup",
   "options/options",
   "content/content",
-  "content/main-world",
+  "content/main-world-entry",
   "background/service-worker",
 ] as const;
 

--- a/e2e/tests/pdf-workflow.spec.ts
+++ b/e2e/tests/pdf-workflow.spec.ts
@@ -69,7 +69,6 @@ test.describe("PDF Signing Workflow", () => {
         try {
           const response = await chrome.runtime.sendMessage({
             payload: {
-              originalFilename: "test.pdf",
               pdfBytes: [...new Uint8Array(100)],
               senderLastname: "Test",
             },

--- a/e2e/tests/security.spec.ts
+++ b/e2e/tests/security.spec.ts
@@ -20,7 +20,7 @@ test.describe("Origin Validation", () => {
       async () => {
         try {
           const response = await chrome.runtime.sendMessage({
-            payload: { originalFilename: "test.pdf", pdfBytes: [], senderLastname: "Test" },
+            payload: { pdfBytes: [], senderLastname: "Test" },
             type: "SIGN_PDF",
           });
           return { response, status: "responded" };

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -4,7 +4,7 @@ export default {
   entry: [
     "src/background/service-worker.ts",
     "src/content/content.ts",
-    "src/content/main-world.ts",
+    "src/content/main-world-entry.ts",
     "src/options/options.ts",
     "src/popup/popup.ts",
     "scripts/*.ts",

--- a/manifest.json
+++ b/manifest.json
@@ -32,7 +32,7 @@
         "https://outlook.office.com/mail/*",
         "https://outlook.live.com/mail/*"
       ],
-      "js": ["content/main-world.js"],
+      "js": ["content/main-world-entry.js"],
       "run_at": "document_start",
       "world": "MAIN"
     },

--- a/src/background/service-worker.test.ts
+++ b/src/background/service-worker.test.ts
@@ -36,7 +36,6 @@ async function createMinimalPdf(): Promise<Uint8Array> {
 
 describe("signPdfFromRequest", () => {
   const request: SignPdfRequest = {
-    originalFilename: "attachment.pdf",
     pdfBytes: [],
     senderLastname: "DUPONT",
   };

--- a/src/content/content.test.ts
+++ b/src/content/content.test.ts
@@ -1,0 +1,161 @@
+import { afterAll, beforeEach, describe, expect, test, vi } from "vite-plus/test";
+
+/* eslint-disable unicorn/no-null -- Chrome mock setup */
+import { type PopupToContentMessage, type WorkflowResult } from "#shared/messages.js";
+
+const originalChrome = (globalThis as Record<string, unknown>).chrome;
+
+type MessageListener<TMessage, TResponse> = (
+  message: TMessage,
+  sender: chrome.runtime.MessageSender,
+  sendResponse: (response: TResponse) => void,
+) => boolean;
+
+function captureResponse<T>(): {
+  mock: (response: T) => void;
+  promise: Promise<T>;
+} {
+  const { promise, resolve } = Promise.withResolvers<T>();
+  return {
+    mock: vi.fn<(response: T) => void>((response: T) => {
+      resolve(response);
+    }),
+    promise,
+  };
+}
+
+vi.mock("./outlook-dom.js", () => ({
+  collectPdfAttachments: vi.fn(async () => []),
+}));
+vi.mock("./outlook-compose.js", () => ({
+  prepareDrafts: vi.fn(async () => ({ errors: [], successCount: 0 })),
+}));
+
+const { collectPdfAttachments } = await import("./outlook-dom.js");
+const { prepareDrafts } = await import("./outlook-compose.js");
+
+const addListenerMock = vi.fn();
+const sendMessageMock = vi.fn();
+// eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- Partial chrome mock for testing
+(globalThis as Record<string, unknown>).chrome = {
+  runtime: {
+    id: "test-extension-id",
+    onMessage: { addListener: addListenerMock },
+    sendMessage: sendMessageMock,
+  },
+  storage: {
+    sync: { get: vi.fn(async () => ({ myEmail: "test@example.com", replyMessage: "Ok" })) },
+  },
+};
+
+const originalDocument = globalThis.document;
+// eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- Stub document for module load
+globalThis.document = {
+  addEventListener: vi.fn(),
+  documentElement: { dataset: {} },
+} as unknown as typeof globalThis.document;
+await import("./content.js");
+globalThis.document = originalDocument;
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion, @typescript-eslint/no-non-null-assertion -- Mock call args
+const contentHandler = addListenerMock.mock.calls[0]![0] as MessageListener<
+  PopupToContentMessage,
+  WorkflowResult
+>;
+
+afterAll(() => {
+  // eslint-disable-next-line @typescript-eslint/no-dynamic-delete -- Restore original global state
+  if (originalChrome === undefined) {
+    delete (globalThis as Record<string, unknown>).chrome;
+  } else {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- Restore original global state
+    globalThis.chrome = originalChrome as typeof chrome;
+  }
+});
+
+const validMessage: PopupToContentMessage = {
+  config: { myEmail: "me@example.com", replyMessage: "OK" },
+  type: "START_WORKFLOW",
+};
+
+describe("signAndDraft via onMessage", () => {
+  beforeEach(() => {
+    vi.mocked(collectPdfAttachments).mockReset();
+    vi.mocked(prepareDrafts).mockReset();
+    sendMessageMock.mockReset();
+  });
+
+  test("runs sign + draft pipeline for each attachment on the happy path", async () => {
+    // Given
+    vi.mocked(collectPdfAttachments).mockResolvedValueOnce([
+      { conversationId: "conv-1", pdfBytes: new Uint8Array([1]), senderLastname: "DUPONT" },
+      { conversationId: "conv-2", pdfBytes: new Uint8Array([2]), senderLastname: "MARTIN" },
+    ]);
+    sendMessageMock.mockResolvedValue({
+      filename: "signed.pdf",
+      signedPdf: [9, 9],
+      success: true,
+    });
+    vi.mocked(prepareDrafts).mockResolvedValueOnce({ errors: [], successCount: 2 });
+    const { mock: sendResponse, promise } = captureResponse<WorkflowResult>();
+
+    // When
+    const keepOpen = contentHandler(validMessage, { id: "test-extension-id" }, sendResponse);
+
+    // Then
+    expect({
+      keepOpen,
+      result: await promise,
+      signCalls: sendMessageMock.mock.calls.length,
+    }).toEqual({
+      keepOpen: true,
+      result: { kind: "processed", success: true, successCount: 2, totalCount: 2 },
+      signCalls: 2,
+    });
+  });
+
+  test("returns workflow-error when signing fails", async () => {
+    // Given
+    vi.mocked(collectPdfAttachments).mockResolvedValueOnce([
+      { conversationId: "conv-1", pdfBytes: new Uint8Array([1]), senderLastname: "DUPONT" },
+    ]);
+    sendMessageMock.mockResolvedValueOnce({ error: "No signature configured", success: false });
+    const { mock: sendResponse, promise } = captureResponse<WorkflowResult>();
+
+    // When
+    contentHandler(validMessage, { id: "test-extension-id" }, sendResponse);
+
+    // Then
+    expect(await promise).toEqual({
+      error: "Signing failed: No signature configured",
+      kind: "workflow-error",
+      success: false,
+    });
+  });
+
+  test("returns partial-failure with structured errors when some drafts fail", async () => {
+    // Given
+    vi.mocked(collectPdfAttachments).mockResolvedValueOnce([
+      { conversationId: "conv-1", pdfBytes: new Uint8Array([1]), senderLastname: "DUPONT" },
+      { conversationId: "conv-2", pdfBytes: new Uint8Array([2]), senderLastname: "MARTIN" },
+    ]);
+    sendMessageMock.mockResolvedValue({ filename: "signed.pdf", signedPdf: [0], success: true });
+    vi.mocked(prepareDrafts).mockResolvedValueOnce({
+      errors: [{ index: 2, message: "compose unavailable" }],
+      successCount: 1,
+    });
+    const { mock: sendResponse, promise } = captureResponse<WorkflowResult>();
+
+    // When
+    contentHandler(validMessage, { id: "test-extension-id" }, sendResponse);
+
+    // Then
+    expect(await promise).toEqual({
+      draftErrors: [{ index: 2, message: "compose unavailable" }],
+      kind: "partial-failure",
+      success: false,
+      successCount: 1,
+      totalCount: 2,
+    });
+  });
+});

--- a/src/content/content.ts
+++ b/src/content/content.ts
@@ -12,13 +12,9 @@ import { getSyncStorage } from "#shared/storage.js";
 import { type SignedPdfItem, prepareDrafts } from "./outlook-compose.js";
 import { collectPdfAttachments } from "./outlook-dom.js";
 
-function signPdf(
-  pdfBytes: Uint8Array,
-  originalFilename: string,
-  senderLastname: string,
-): Promise<SignPdfResponse> {
+function signPdf(pdfBytes: Uint8Array, senderLastname: string): Promise<SignPdfResponse> {
   return chrome.runtime.sendMessage<ContentToBackgroundMessage, SignPdfResponse>({
-    payload: { originalFilename, pdfBytes: [...pdfBytes], senderLastname },
+    payload: { pdfBytes: [...pdfBytes], senderLastname },
     type: "SIGN_PDF",
   });
 }
@@ -33,11 +29,7 @@ async function signAndDraft(config: WorkflowConfig): Promise<WorkflowResult> {
 
     const items: SignedPdfItem[] = await Promise.all(
       attachments.map(async (attachment) => {
-        const response = await signPdf(
-          attachment.pdfBytes,
-          attachment.originalFilename,
-          attachment.senderLastname,
-        );
+        const response = await signPdf(attachment.pdfBytes, attachment.senderLastname);
 
         if (!response.success) {
           throw new Error(`Signing failed: ${response.error}`);

--- a/src/content/content.ts
+++ b/src/content/content.ts
@@ -12,7 +12,7 @@ import { getSyncStorage } from "#shared/storage.js";
 import { type SignedPdfItem, prepareDrafts } from "./outlook-compose.js";
 import { collectPdfAttachments } from "./outlook-dom.js";
 
-function signPdf(pdfBytes: Uint8Array, senderLastname: string): Promise<SignPdfResponse> {
+function requestSignPdf(pdfBytes: Uint8Array, senderLastname: string): Promise<SignPdfResponse> {
   return chrome.runtime.sendMessage<ContentToBackgroundMessage, SignPdfResponse>({
     payload: { pdfBytes: [...pdfBytes], senderLastname },
     type: "SIGN_PDF",
@@ -24,12 +24,12 @@ async function signAndDraft(config: WorkflowConfig): Promise<WorkflowResult> {
     const attachments = await collectPdfAttachments(config.myEmail);
 
     if (attachments.length === 0) {
-      return { message: "No PDFs found in current conversation", success: true };
+      return { kind: "processed", success: true, successCount: 0, totalCount: 0 };
     }
 
     const items: SignedPdfItem[] = await Promise.all(
       attachments.map(async (attachment) => {
-        const response = await signPdf(attachment.pdfBytes, attachment.senderLastname);
+        const response = await requestSignPdf(attachment.pdfBytes, attachment.senderLastname);
 
         if (!response.success) {
           throw new Error(`Signing failed: ${response.error}`);
@@ -38,10 +38,7 @@ async function signAndDraft(config: WorkflowConfig): Promise<WorkflowResult> {
         return {
           conversationId: attachment.conversationId,
           filename: response.filename,
-          senderEmail: attachment.senderEmail,
-          senderLastname: attachment.senderLastname,
           signedPdf: new Uint8Array(response.signedPdf),
-          subject: attachment.subject,
         };
       }),
     );
@@ -50,18 +47,23 @@ async function signAndDraft(config: WorkflowConfig): Promise<WorkflowResult> {
 
     if (errors.length > 0) {
       return {
-        message: `${successCount}/${items.length} drafts. Failures: ${errors.join("; ")}`,
+        draftErrors: errors,
+        kind: "partial-failure",
         success: false,
+        successCount,
+        totalCount: items.length,
       };
     }
 
     return {
-      message: `Processed ${successCount}/${items.length} emails`,
+      kind: "processed",
       success: true,
+      successCount,
+      totalCount: items.length,
     };
   } catch (error) {
     console.error("[OPM] Workflow error:", error);
-    return { message: getErrorMessage(error), success: false };
+    return { error: getErrorMessage(error), kind: "workflow-error", success: false };
   }
 }
 
@@ -99,7 +101,7 @@ chrome.runtime.onMessage.addListener(
     signAndDraft(message.config)
       .then(sendResponse)
       .catch((error: unknown) => {
-        sendResponse({ message: getErrorMessage(error), success: false });
+        sendResponse({ error: getErrorMessage(error), kind: "workflow-error", success: false });
       });
     return true;
   },

--- a/src/content/main-world-entry.ts
+++ b/src/content/main-world-entry.ts
@@ -1,0 +1,3 @@
+import { installMainWorld } from "./main-world.js";
+
+installMainWorld();

--- a/src/content/main-world.test.ts
+++ b/src/content/main-world.test.ts
@@ -1,12 +1,13 @@
 /// <reference lib="dom" />
 /* eslint-disable unicorn/no-null, unicorn/prefer-global-this, promise/avoid-new -- DOM test fixtures with window API */
-import { afterEach, beforeAll, describe, expect, test } from "vite-plus/test";
+import { afterAll, afterEach, beforeAll, describe, expect, test } from "vite-plus/test";
 
 import {
   type BlobCapturedMessage,
   type BlobRequestMessage,
   type BlobResultMessage,
 } from "./blob-protocol.js";
+import { installMainWorld } from "./main-world.js";
 
 type PostedMessage = BlobCapturedMessage | BlobResultMessage;
 
@@ -65,9 +66,14 @@ async function flush(): Promise<void> {
 
 describe("main-world", () => {
   let cleanupMessages: (() => void) | undefined;
+  let uninstall: (() => void) | undefined;
 
-  beforeAll(async () => {
-    await import("./main-world.js");
+  beforeAll(() => {
+    uninstall = installMainWorld();
+  });
+
+  afterAll(() => {
+    uninstall?.();
   });
 
   afterEach(() => {

--- a/src/content/main-world.test.ts
+++ b/src/content/main-world.test.ts
@@ -40,7 +40,9 @@ function collectMessages(): { messages: PostedMessage[]; cleanup: () => void } {
 
 function sendBlobRequest(id: string, url: string): void {
   const data: BlobRequestMessage = { id, type: "OPM_GET_BLOB", url };
-  window.dispatchEvent(new MessageEvent("message", { data, source: window }));
+  window.dispatchEvent(
+    new MessageEvent("message", { data, origin: window.location.origin, source: window }),
+  );
 }
 
 function waitForBlobResult(): Promise<BlobResultMessage> {

--- a/src/content/main-world.ts
+++ b/src/content/main-world.ts
@@ -16,16 +16,6 @@ function isBlobMessage(data: unknown): data is BlobRequestMessage {
 
 const capturedBlobs = new Map<string, Blob>();
 
-const originalCreateObjectURL = URL.createObjectURL.bind(URL);
-URL.createObjectURL = (obj: Blob | MediaSource): string => {
-  const url = originalCreateObjectURL(obj);
-  if (obj instanceof Blob && obj.type === "application/pdf") {
-    capturedBlobs.set(url, obj);
-    window.postMessage({ type: "OPM_BLOB_CAPTURED", url }, window.location.origin);
-  }
-  return url;
-};
-
 async function postBlobResult(id: string, url: string): Promise<void> {
   const blob = capturedBlobs.get(url);
 
@@ -57,23 +47,46 @@ async function postBlobResult(id: string, url: string): Promise<void> {
   }
 }
 
-window.addEventListener("message", (event: MessageEvent) => {
-  if (event.source !== window || !isBlobMessage(event.data)) {
-    return;
-  }
-  const { id, url } = event.data;
-  // eslint-disable-next-line promise/prefer-await-to-callbacks -- Event listener cannot be async
-  postBlobResult(id, url).catch((error: unknown) => {
-    window.postMessage(
-      {
-        error: getErrorMessage(error),
-        id,
-        type: "OPM_BLOB_RESULT",
-      },
-      window.location.origin,
-    );
-  });
-});
+export function installMainWorld(): () => void {
+  const originalCreateObjectURL = URL.createObjectURL.bind(URL);
+  URL.createObjectURL = (obj: Blob | MediaSource): string => {
+    const url = originalCreateObjectURL(obj);
+    if (obj instanceof Blob && obj.type === "application/pdf") {
+      capturedBlobs.set(url, obj);
+      window.postMessage({ type: "OPM_BLOB_CAPTURED", url }, window.location.origin);
+    }
+    return url;
+  };
 
-// Sentinel export — ensures bundler treats this as a module (required for Chrome MAIN world injection)
-export type MainWorldModule = true;
+  function onMessage(event: MessageEvent): void {
+    if (
+      event.source !== window ||
+      event.origin !== window.location.origin ||
+      !isBlobMessage(event.data)
+    ) {
+      return;
+    }
+    const { id, url } = event.data;
+    // eslint-disable-next-line promise/prefer-await-to-callbacks -- Event listener cannot be async
+    postBlobResult(id, url).catch((error: unknown) => {
+      window.postMessage(
+        {
+          error: getErrorMessage(error),
+          id,
+          type: "OPM_BLOB_RESULT",
+        },
+        window.location.origin,
+      );
+    });
+  }
+
+  window.addEventListener("message", onMessage);
+
+  return () => {
+    window.removeEventListener("message", onMessage);
+    URL.createObjectURL = originalCreateObjectURL;
+    capturedBlobs.clear();
+  };
+}
+
+installMainWorld();

--- a/src/content/main-world.ts
+++ b/src/content/main-world.ts
@@ -4,13 +4,14 @@ import { getErrorMessage } from "#shared/errors.js";
 import { type BlobRequestMessage } from "./blob-protocol.js";
 
 function isBlobMessage(data: unknown): data is BlobRequestMessage {
+  if (typeof data !== "object" || data === null || !("type" in data)) {
+    return false;
+  }
+  const record = data as Readonly<Record<string, unknown>>;
   return (
-    typeof data === "object" &&
-    data !== null &&
-    "type" in data &&
-    data.type === "OPM_GET_BLOB" &&
-    "id" in data &&
-    "url" in data
+    record.type === "OPM_GET_BLOB" &&
+    typeof record.id === "string" &&
+    typeof record.url === "string"
   );
 }
 
@@ -34,7 +35,7 @@ async function postBlobResult(id: string, url: string): Promise<void> {
       window.location.origin,
     );
     capturedBlobs.delete(url);
-  } catch (error: unknown) {
+  } catch (error) {
     capturedBlobs.delete(url);
     window.postMessage(
       {
@@ -88,5 +89,3 @@ export function installMainWorld(): () => void {
     capturedBlobs.clear();
   };
 }
-
-installMainWorld();

--- a/src/content/outlook-compose.test.ts
+++ b/src/content/outlook-compose.test.ts
@@ -1,19 +1,110 @@
 /// <reference lib="dom" />
 /* eslint-disable unicorn/no-null -- DOM test fixtures */
-import { afterEach, describe, expect, test } from "vite-plus/test";
+import { afterEach, describe, expect, test, vi } from "vite-plus/test";
 
-import { type DraftResult, prepareDrafts } from "./outlook-compose.js";
+vi.mock("./outlook-compose-actions.js", () => ({
+  attachFile: vi.fn(async () => {
+    /* Noop */
+  }),
+  closeCompose: vi.fn(async () => {
+    /* Noop */
+  }),
+  openReply: vi.fn(async () => {
+    const el = document.createElement("div");
+    el.setAttribute("role", "textbox");
+    el.setAttribute("contenteditable", "true");
+    document.body.append(el);
+    return el;
+  }),
+  removeAllAttachments: vi.fn(async () => {
+    /* Noop */
+  }),
+  saveDraft: vi.fn(async () => {
+    /* Noop */
+  }),
+}));
+
+vi.mock("./outlook-automation.js", async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    simulateKeyPress: vi.fn(),
+    sleep: vi.fn(async () => {
+      /* Noop */
+    }),
+    typeText: vi.fn(),
+  };
+});
+
+const { prepareDrafts } = await import("./outlook-compose.js");
+const composeActions = await import("./outlook-compose-actions.js");
+
+function makeItem(idx: number): Parameters<typeof prepareDrafts>[0][number] {
+  return {
+    conversationId: `conv-${idx}`,
+    filename: `attachment-${idx}.pdf`,
+    senderEmail: `sender${idx}@example.com`,
+    senderLastname: `LASTNAME${idx}`,
+    signedPdf: new Uint8Array([idx]),
+    subject: `Subject ${idx}`,
+  };
+}
 
 afterEach(() => {
   document.body.innerHTML = "";
+  vi.clearAllMocks();
 });
 
 describe("prepareDrafts", () => {
   test("returns zero success and no errors for empty items", async () => {
     // Given / When
-    const result: DraftResult = await prepareDrafts([], "Hello");
+    const result = await prepareDrafts([], "Hello");
 
     // Then
     expect(result).toEqual({ errors: [], successCount: 0 });
+  });
+
+  test("drives the full draft pipeline for every item on happy path", async () => {
+    // Given
+    const items = [makeItem(1), makeItem(2)];
+
+    // When
+    const result = await prepareDrafts(items, "Reply body");
+
+    // Then
+    expect(result).toEqual({ errors: [], successCount: 2 });
+    expect({
+      attachFileCalls: vi.mocked(composeActions.attachFile).mock.calls,
+      closeCalls: vi.mocked(composeActions.closeCompose).mock.calls.length,
+      openCalls: vi.mocked(composeActions.openReply).mock.calls,
+      removeAttachmentCalls: vi.mocked(composeActions.removeAllAttachments).mock.calls.length,
+      saveCalls: vi.mocked(composeActions.saveDraft).mock.calls.length,
+    }).toEqual({
+      attachFileCalls: [
+        [items[0]?.signedPdf, items[0]?.filename],
+        [items[1]?.signedPdf, items[1]?.filename],
+      ],
+      closeCalls: 2,
+      openCalls: [[items[0]?.conversationId], [items[1]?.conversationId]],
+      removeAttachmentCalls: 2,
+      saveCalls: 2,
+    });
+  });
+
+  test("collects per-item errors with 1-based index prefix and continues processing", async () => {
+    // Given
+    vi.mocked(composeActions.openReply).mockImplementationOnce(async () => {
+      throw new Error("compose unavailable");
+    });
+    const items = [makeItem(1), makeItem(2)];
+
+    // When
+    const result = await prepareDrafts(items, "Reply body");
+
+    // Then
+    expect(result).toEqual({
+      errors: ["[1] compose unavailable"],
+      successCount: 1,
+    });
   });
 });

--- a/src/content/outlook-compose.test.ts
+++ b/src/content/outlook-compose.test.ts
@@ -43,10 +43,7 @@ function makeItem(idx: number): Parameters<typeof prepareDrafts>[0][number] {
   return {
     conversationId: `conv-${idx}`,
     filename: `attachment-${idx}.pdf`,
-    senderEmail: `sender${idx}@example.com`,
-    senderLastname: `LASTNAME${idx}`,
     signedPdf: new Uint8Array([idx]),
-    subject: `Subject ${idx}`,
   };
 }
 
@@ -103,7 +100,7 @@ describe("prepareDrafts", () => {
 
     // Then
     expect(result).toEqual({
-      errors: ["[1] compose unavailable"],
+      errors: [{ index: 1, message: "compose unavailable" }],
       successCount: 1,
     });
   });

--- a/src/content/outlook-compose.ts
+++ b/src/content/outlook-compose.ts
@@ -1,4 +1,5 @@
 import { getErrorMessage } from "#shared/errors.js";
+import { type DraftError } from "#shared/messages.js";
 
 import { TIMING, simulateKeyPress, sleep, typeText } from "./outlook-automation.js";
 import {
@@ -8,17 +9,15 @@ import {
   removeAllAttachments,
   saveDraft,
 } from "./outlook-compose-actions.js";
+
 export interface SignedPdfItem {
   readonly conversationId: string;
   readonly filename: string;
-  readonly senderEmail: string;
-  readonly senderLastname: string;
   readonly signedPdf: Uint8Array;
-  readonly subject: string;
 }
 
 export interface DraftResult {
-  readonly errors: readonly string[];
+  readonly errors: readonly DraftError[];
   readonly successCount: number;
 }
 
@@ -28,7 +27,7 @@ export async function prepareDrafts(
   replyMessage: string,
 ): Promise<DraftResult> {
   let successCount = 0;
-  const errors: string[] = [];
+  const errors: DraftError[] = [];
 
   for (const [idx, item] of items.entries()) {
     simulateKeyPress("Escape");
@@ -46,7 +45,7 @@ export async function prepareDrafts(
       await sleep(TIMING.UI_SETTLE);
       successCount += 1;
     } catch (error) {
-      errors.push(`[${idx + 1}] ${getErrorMessage(error)}`);
+      errors.push({ index: idx + 1, message: getErrorMessage(error) });
     }
   }
 

--- a/src/content/outlook-dom.test.ts
+++ b/src/content/outlook-dom.test.ts
@@ -4,7 +4,6 @@ import { afterEach, describe, expect, test, vi } from "vite-plus/test";
 
 interface MockMessageInfo {
   readonly element: Element;
-  readonly senderEmail: string;
   readonly senderLastname: string;
 }
 
@@ -15,7 +14,6 @@ function findMessageInDom(): MockMessageInfo | undefined {
   }
   return {
     element: messageEl,
-    senderEmail: "dupont@example.com",
     senderLastname: "DUPONT",
   };
 }
@@ -102,22 +100,9 @@ describe("collectPdfAttachments happy path", () => {
       {
         conversationId: "conv-123",
         pdfBytes: new Uint8Array([10, 20, 30]),
-        senderEmail: "dupont@example.com",
         senderLastname: "DUPONT",
-        subject: "Project update",
       },
     ]);
-  });
-
-  test("strips trailing 'Summarize' from the subject heading", async () => {
-    // Given
-    renderHappyPathDom("Project updateSummarize");
-
-    // When
-    const [attachment] = await collectPdfAttachments("me@example.com");
-
-    // Then
-    expect(attachment?.subject).toBe("Project update");
   });
 
   test("returns empty when the listbox has no PDF options", async () => {

--- a/src/content/outlook-dom.test.ts
+++ b/src/content/outlook-dom.test.ts
@@ -1,39 +1,141 @@
 /// <reference lib="dom" />
 /* eslint-disable unicorn/no-null -- DOM test fixtures */
-import { afterEach, describe, expect, test } from "vite-plus/test";
+import { afterEach, describe, expect, test, vi } from "vite-plus/test";
 
-// The helper getConversationContext is not exported, so test collectPdfAttachments indirectly
-// By verifying the DOM parsing logic through the public API
+interface MockMessageInfo {
+  readonly element: Element;
+  readonly senderEmail: string;
+  readonly senderLastname: string;
+}
+
+function findMessageInDom(): MockMessageInfo | undefined {
+  const messageEl = document.querySelector<HTMLElement>("[data-test-message]");
+  if (!messageEl) {
+    return undefined;
+  }
+  return {
+    element: messageEl,
+    senderEmail: "dupont@example.com",
+    senderLastname: "DUPONT",
+  };
+}
+
+vi.mock("./outlook-actions.js", () => ({
+  expandMessage: vi.fn(async () => {
+    /* Noop */
+  }),
+  expandThread: vi.fn(async () => {
+    /* Noop */
+  }),
+  findAttachmentListbox: vi.fn((message: Element): Element | null =>
+    message.querySelector('[role="listbox"]'),
+  ),
+  findLastMessageFromOthers: vi.fn(findMessageInDom),
+  findPdfOptions: vi.fn((listbox: Element): Element[] => [
+    ...listbox.querySelectorAll('[role="option"]'),
+  ]),
+}));
+
+vi.mock("./outlook-download.js", () => ({
+  downloadAttachment: vi.fn(async () => new Uint8Array([10, 20, 30])),
+}));
+
+const { collectPdfAttachments } = await import("./outlook-dom.js");
+
+function renderHappyPathDom(subject: string): void {
+  document.body.innerHTML = `
+    <div role="main">
+      <div role="heading" aria-level="2">${subject}</div>
+      <div data-convid="conv-123" aria-selected="true"></div>
+      <div data-test-message>
+        <div role="listbox">
+          <div role="option">invoice-2026.pdf</div>
+        </div>
+      </div>
+    </div>
+  `;
+}
+
+afterEach(() => {
+  document.body.innerHTML = "";
+  vi.clearAllMocks();
+});
 
 describe("collectPdfAttachments DOM prerequisites", () => {
-  afterEach(() => {
-    document.body.innerHTML = "";
-  });
-
   test("returns empty when no reading pane exists", async () => {
     // Given: empty document with no [role="main"]
     document.body.innerHTML = "<div>empty</div>";
 
-    // When: we import and call collectPdfAttachments
-    const { collectPdfAttachments } = await import("./outlook-dom.js");
+    // When
     const result = await collectPdfAttachments("test@example.com");
 
-    // Then: returns empty array
+    // Then
     expect(result).toEqual([]);
   });
 
-  test("returns empty when reading pane has no sender messages", async () => {
-    // Given: reading pane with heading but no sender buttons
+  test("returns empty when no conversation is selected", async () => {
+    // Given
     document.body.innerHTML = `
       <div role="main">
         <div role="heading" aria-level="2">Test Subject</div>
       </div>
     `;
 
-    const { collectPdfAttachments } = await import("./outlook-dom.js");
+    // When
     const result = await collectPdfAttachments("me@example.com");
 
-    // Then: returns empty (no message from others found)
+    // Then
+    expect(result).toEqual([]);
+  });
+});
+
+describe("collectPdfAttachments happy path", () => {
+  test("assembles PdfAttachment from DOM + downloaded bytes", async () => {
+    // Given
+    renderHappyPathDom("Project update");
+
+    // When
+    const result = await collectPdfAttachments("me@example.com");
+
+    // Then
+    expect(result).toEqual([
+      {
+        conversationId: "conv-123",
+        pdfBytes: new Uint8Array([10, 20, 30]),
+        senderEmail: "dupont@example.com",
+        senderLastname: "DUPONT",
+        subject: "Project update",
+      },
+    ]);
+  });
+
+  test("strips trailing 'Summarize' from the subject heading", async () => {
+    // Given
+    renderHappyPathDom("Project updateSummarize");
+
+    // When
+    const [attachment] = await collectPdfAttachments("me@example.com");
+
+    // Then
+    expect(attachment?.subject).toBe("Project update");
+  });
+
+  test("returns empty when the listbox has no PDF options", async () => {
+    // Given
+    document.body.innerHTML = `
+      <div role="main">
+        <div role="heading" aria-level="2">Subject</div>
+        <div data-convid="conv-42" aria-selected="true"></div>
+        <div data-test-message>
+          <div role="listbox"></div>
+        </div>
+      </div>
+    `;
+
+    // When
+    const result = await collectPdfAttachments("me@example.com");
+
+    // Then
     expect(result).toEqual([]);
   });
 });

--- a/src/content/outlook-dom.ts
+++ b/src/content/outlook-dom.ts
@@ -10,43 +10,29 @@ import { downloadAttachment } from "./outlook-download.js";
 export interface PdfAttachment {
   readonly conversationId: string;
   readonly pdfBytes: Uint8Array;
-  readonly senderEmail: string;
   readonly senderLastname: string;
-  readonly subject: string;
 }
 
-function findConversationContext(): { conversationId: string; subject: string } | undefined {
+function findConversationId(): string | undefined {
   const readingPane = document.querySelector('[role="main"]');
   if (!readingPane) {
     return undefined;
   }
 
-  const subjectEl = readingPane.querySelector('[role="heading"][aria-level="2"]');
-  const subject = (subjectEl?.textContent ?? "Unknown")
-    .trim()
-    .replace(/Summarize$/, "")
-    .trim();
-
   const selectedEmail = document.querySelector<HTMLElement>(
     '[data-convid][aria-selected="true"], [data-convid]:focus',
   );
   const conversationId = selectedEmail?.dataset.convid ?? "";
-  if (conversationId === "") {
-    return undefined;
-  }
-
-  return { conversationId, subject };
+  return conversationId === "" ? undefined : conversationId;
 }
 
 // Returns [] when no PDF is found (missing DOM state). Throws on expand or download failure.
 // Currently returns at most one attachment but the array contract allows future extension.
 export async function collectPdfAttachments(myEmail: string): Promise<PdfAttachment[]> {
-  const context = findConversationContext();
-  if (!context) {
+  const conversationId = findConversationId();
+  if (conversationId === undefined) {
     return [];
   }
-
-  const { subject, conversationId } = context;
 
   await expandThread();
 
@@ -73,9 +59,7 @@ export async function collectPdfAttachments(myEmail: string): Promise<PdfAttachm
     {
       conversationId,
       pdfBytes,
-      senderEmail: message.senderEmail,
       senderLastname: message.senderLastname,
-      subject,
     },
   ];
 }

--- a/src/content/outlook-dom.ts
+++ b/src/content/outlook-dom.ts
@@ -9,7 +9,6 @@ import { downloadAttachment } from "./outlook-download.js";
 
 export interface PdfAttachment {
   readonly conversationId: string;
-  readonly originalFilename: string;
   readonly pdfBytes: Uint8Array;
   readonly senderEmail: string;
   readonly senderLastname: string;
@@ -68,14 +67,11 @@ export async function collectPdfAttachments(myEmail: string): Promise<PdfAttachm
     return [];
   }
 
-  const originalFilename = /^(.+\.pdf)/i.exec(firstPdf.textContent ?? "")?.[1] ?? "attachment.pdf";
-
   const pdfBytes = await downloadAttachment(firstPdf);
 
   return [
     {
       conversationId,
-      originalFilename,
       pdfBytes,
       senderEmail: message.senderEmail,
       senderLastname: message.senderLastname,

--- a/src/content/outlook-download.test.ts
+++ b/src/content/outlook-download.test.ts
@@ -1,25 +1,137 @@
 /// <reference lib="dom" />
-/* eslint-disable unicorn/no-null -- DOM test fixtures */
-import { afterEach, describe, expect, test } from "vite-plus/test";
+/* eslint-disable unicorn/no-null, unicorn/prefer-global-this -- DOM test fixtures with window API */
+import { afterEach, describe, expect, test, vi } from "vite-plus/test";
 
-// Verify downloadAttachment contract through its error paths
-// Type guards and blob protocol are internal
+import {
+  type BlobCapturedMessage,
+  type BlobRequestMessage,
+  type BlobResultMessage,
+} from "./blob-protocol.js";
+vi.mock("./outlook-automation.js", async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    simulateClick: vi.fn(),
+    simulateKeyPress: vi.fn(),
+    sleep: vi.fn(async () => {
+      /* Noop */
+    }),
+  };
+});
+
+const { downloadAttachment } = await import("./outlook-download.js");
+const automation = await import("./outlook-automation.js");
+
+function setPathname(path: string): void {
+  window.history.replaceState({}, "", path);
+}
+
+function renderDownloadMenuItem(label = "Download"): void {
+  const btn = document.createElement("div");
+  btn.setAttribute("role", "menuitem");
+  btn.textContent = label;
+  document.body.append(btn);
+}
+
+// Happy-dom's window.postMessage does not set event.source=window; dispatch directly instead.
+function dispatchOpmMessage(data: BlobCapturedMessage | BlobResultMessage): void {
+  window.dispatchEvent(
+    new MessageEvent("message", { data, origin: window.location.origin, source: window }),
+  );
+}
+
+function isBlobRequest(data: unknown): data is BlobRequestMessage {
+  return (
+    typeof data === "object" &&
+    data !== null &&
+    "type" in data &&
+    (data as Readonly<{ type: unknown }>).type === "OPM_GET_BLOB"
+  );
+}
+
+function onBlobRequest(handler: (request: BlobRequestMessage) => void): () => void {
+  function listener(event: MessageEvent): void {
+    if (!isBlobRequest(event.data)) {
+      return;
+    }
+    handler(event.data);
+  }
+  window.addEventListener("message", listener);
+  return () => {
+    window.removeEventListener("message", listener);
+  };
+}
+
+function postCapturedOnDownloadClick(url: string): void {
+  vi.mocked(automation.simulateClick).mockImplementation((el: Element) => {
+    if (el.getAttribute("role") === "menuitem") {
+      dispatchOpmMessage({ type: "OPM_BLOB_CAPTURED", url });
+    }
+  });
+}
+
+afterEach(() => {
+  document.body.innerHTML = "";
+  setPathname("/");
+  vi.clearAllMocks();
+});
 
 describe("outlook-download module", () => {
-  afterEach(() => {
-    document.body.innerHTML = "";
-  });
-
   test("downloadAttachment throws when attachment URL never appears", async () => {
-    // Given: an element that can be clicked but no /sxs/ URL navigation occurs
+    // Given
+    setPathname("/");
     const option = document.createElement("div");
     option.setAttribute("role", "option");
     option.textContent = "test.pdf";
     document.body.append(option);
 
-    const { downloadAttachment } = await import("./outlook-download.js");
-
-    // When/Then: throws because waitUntilAttachmentReady times out
+    // When / Then
     await expect(downloadAttachment(option)).rejects.toThrow("Attachment ID not found in URL");
+  });
+
+  test("downloadAttachment returns PDF bytes on the happy path", async () => {
+    // Given
+    setPathname("/mail/sxs/msg-1");
+    renderDownloadMenuItem();
+    const option = document.createElement("div");
+    option.setAttribute("role", "option");
+    option.textContent = "invoice.pdf";
+    document.body.append(option);
+
+    const expectedBytes = new Uint8Array([7, 8, 9]);
+    postCapturedOnDownloadClick("blob:http://localhost/captured");
+    const unsubscribe = onBlobRequest((request) => {
+      queueMicrotask(() => {
+        dispatchOpmMessage({ data: expectedBytes, id: request.id, type: "OPM_BLOB_RESULT" });
+      });
+    });
+
+    // When
+    const bytes = await downloadAttachment(option);
+
+    // Then
+    expect(bytes).toEqual(expectedBytes);
+    unsubscribe();
+  });
+
+  test("downloadAttachment surfaces errors from the blob fetch", async () => {
+    // Given
+    setPathname("/mail/sxs/msg-2");
+    renderDownloadMenuItem();
+    const option = document.createElement("div");
+    option.setAttribute("role", "option");
+    option.textContent = "other.pdf";
+    document.body.append(option);
+
+    postCapturedOnDownloadClick("blob:http://localhost/missing");
+    const unsubscribe = onBlobRequest((request) => {
+      queueMicrotask(() => {
+        dispatchOpmMessage({ error: "Blob not found", id: request.id, type: "OPM_BLOB_RESULT" });
+      });
+    });
+
+    // When / Then
+    await expect(downloadAttachment(option)).rejects.toThrow("Blob not found");
+    unsubscribe();
   });
 });

--- a/src/content/outlook-download.ts
+++ b/src/content/outlook-download.ts
@@ -87,7 +87,15 @@ async function waitUntilAttachmentReady(maxAttempts = 20): Promise<void> {
 async function captureAndFetchPdf(trigger: () => void | Promise<void>): Promise<Uint8Array> {
   // Subscribe before triggering so the OPM_BLOB_CAPTURED message cannot race past us
   const capturePromise = waitForWindowMessage<BlobCapturedMessage>(isBlobCaptured, 10_000);
-  await trigger();
+  try {
+    await trigger();
+  } catch (error) {
+    capturePromise.catch(() => {
+      // Swallow potential timeout/unhandled rejection if trigger fails early.
+    });
+    throw error;
+  }
+
   const { url } = await capturePromise;
   return getBlobFromMainWorld(url);
 }

--- a/src/content/outlook-download.ts
+++ b/src/content/outlook-download.ts
@@ -9,20 +9,24 @@ import {
 } from "./outlook-automation.js";
 
 function isBlobCaptured(data: unknown): data is BlobCapturedMessage {
-  return (
-    typeof data === "object" && data !== null && "type" in data && data.type === "OPM_BLOB_CAPTURED"
-  );
+  if (typeof data !== "object" || data === null || !("type" in data)) {
+    return false;
+  }
+  const record = data as Readonly<Record<string, unknown>>;
+  return record.type === "OPM_BLOB_CAPTURED" && typeof record.url === "string";
 }
 
 function isBlobResult(data: unknown, id: string): data is BlobResultMessage {
-  return (
-    typeof data === "object" &&
-    data !== null &&
-    "type" in data &&
-    data.type === "OPM_BLOB_RESULT" &&
-    "id" in data &&
-    data.id === id
-  );
+  if (typeof data !== "object" || data === null || !("type" in data)) {
+    return false;
+  }
+  const record = data as Readonly<Record<string, unknown>>;
+  if (record.type !== "OPM_BLOB_RESULT" || record.id !== id) {
+    return false;
+  }
+  const hasData = "data" in record && record.data instanceof Uint8Array;
+  const hasError = "error" in record && typeof record.error === "string";
+  return hasData || hasError;
 }
 
 function waitForWindowMessage<TMessage>(
@@ -80,25 +84,29 @@ async function waitUntilAttachmentReady(maxAttempts = 20): Promise<void> {
   throw new Error("Attachment ID not found in URL");
 }
 
+async function captureAndFetchPdf(trigger: () => void | Promise<void>): Promise<Uint8Array> {
+  // Subscribe before triggering so the OPM_BLOB_CAPTURED message cannot race past us
+  const capturePromise = waitForWindowMessage<BlobCapturedMessage>(isBlobCaptured, 10_000);
+  await trigger();
+  const { url } = await capturePromise;
+  return getBlobFromMainWorld(url);
+}
+
 export async function downloadAttachment(option: Element): Promise<Uint8Array> {
   simulateClick(option);
   await waitUntilAttachmentReady();
 
-  // Subscribe before triggering download to avoid missing the OPM_BLOB_CAPTURED message
-  const blobPromise = waitForWindowMessage<BlobCapturedMessage>(isBlobCaptured, 10_000);
-
-  await sleep(TIMING.UI_SETTLE);
-  const downloadBtn = await waitForElement('[role="menuitem"]', {
-    match: (el) => {
-      const text = (el.textContent ?? "").toLowerCase();
-      return text.includes("download") || text.includes("télécharger");
-    },
-    timeout: 3000,
+  const pdfBytes = await captureAndFetchPdf(async () => {
+    await sleep(TIMING.UI_SETTLE);
+    const downloadBtn = await waitForElement('[role="menuitem"]', {
+      match: (el) => {
+        const text = (el.textContent ?? "").toLowerCase();
+        return text.includes("download") || text.includes("télécharger");
+      },
+      timeout: 3000,
+    });
+    simulateClick(downloadBtn);
   });
-  simulateClick(downloadBtn);
-
-  const { url } = await blobPromise;
-  const pdfBytes = await getBlobFromMainWorld(url);
 
   simulateKeyPress("Escape");
   await sleep(TIMING.MENU_ANIMATION);

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -221,8 +221,10 @@ describe("content.ts onMessage handler", () => {
     expect(keepOpen).toBe(true);
 
     expect(await promise).toEqual({
-      message: "No PDFs found in current conversation",
+      kind: "processed",
       success: true,
+      successCount: 0,
+      totalCount: 0,
     });
   });
 });

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -117,7 +117,7 @@ afterAll(() => {
 
 describe("service-worker onMessage handler", () => {
   const validMessage: ContentToBackgroundMessage = {
-    payload: { originalFilename: "doc.pdf", pdfBytes: [1, 2, 3], senderLastname: "DUPONT" },
+    payload: { pdfBytes: [1, 2, 3], senderLastname: "DUPONT" },
     type: "SIGN_PDF",
   };
 

--- a/src/popup/popup.test.ts
+++ b/src/popup/popup.test.ts
@@ -1,10 +1,13 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from "vite-plus/test";
 
+import { type WorkflowResult } from "#shared/messages.js";
+
 /* eslint-disable unicorn/no-null -- Chrome mock setup */
 
 const tabsQueryMock = vi.fn(() => Promise.resolve([] as chrome.tabs.Tab[]));
-const tabsSendMessageMock = vi.fn(() =>
-  Promise.resolve({ message: "Processed 1/1 emails", success: true }),
+
+const tabsSendMessageMock = vi.fn<() => Promise<WorkflowResult>>(() =>
+  Promise.resolve({ kind: "processed", success: true, successCount: 1, totalCount: 1 }),
 );
 
 function setupChromeMock(): void {
@@ -72,7 +75,12 @@ describe("popup dispatchWorkflow", () => {
   test("sends correct message and shows success", async () => {
     // Given: valid config and active Outlook tab
     tabsQueryMock.mockResolvedValue([activeTab]);
-    tabsSendMessageMock.mockResolvedValue({ message: "Processed 1/1 emails", success: true });
+    tabsSendMessageMock.mockResolvedValue({
+      kind: "processed",
+      success: true,
+      successCount: 1,
+      totalCount: 1,
+    });
     const { dispatchWorkflow } = await import("./popup.js");
 
     // When
@@ -94,7 +102,11 @@ describe("popup dispatchWorkflow", () => {
   test("shows error when workflow fails", async () => {
     // Given: workflow returns failure
     tabsQueryMock.mockResolvedValue([activeTab]);
-    tabsSendMessageMock.mockResolvedValue({ message: "Signing failed", success: false });
+    tabsSendMessageMock.mockResolvedValue({
+      error: "Signing failed",
+      kind: "workflow-error",
+      success: false,
+    });
     const { dispatchWorkflow } = await import("./popup.js");
 
     // When

--- a/src/popup/popup.ts
+++ b/src/popup/popup.ts
@@ -15,6 +15,22 @@ function showStatus(type: "error" | "info" | "ready" | "warning", message: strin
   status.className = `status ${type}`;
 }
 
+function formatWorkflowResult(result: WorkflowResult): string {
+  if (result.kind === "workflow-error") {
+    return result.error;
+  }
+  if (result.totalCount === 0) {
+    return "No PDFs found in current conversation";
+  }
+  if (result.kind === "partial-failure") {
+    const failures = result.draftErrors
+      .map(({ index, message }) => `[${index}] ${message}`)
+      .join("; ");
+    return `${result.successCount}/${result.totalCount} drafts. Failures: ${failures}`;
+  }
+  return `Processed ${result.successCount}/${result.totalCount} emails`;
+}
+
 function setProgress(show: boolean, value = 0, text = ""): void {
   const progress = getElement<HTMLDivElement>("progress");
   progress.classList.toggle("hidden", !show);
@@ -115,11 +131,8 @@ export async function dispatchWorkflow(): Promise<void> {
 
     setProgress(false);
 
-    if (result.success) {
-      showStatus("ready", result.message);
-    } else {
-      showStatus("error", result.message);
-    }
+    const message = formatWorkflowResult(result);
+    showStatus(result.success ? "ready" : "error", message);
   } catch (error) {
     setProgress(false);
     const message = getErrorMessage(error);

--- a/src/shared/messages.ts
+++ b/src/shared/messages.ts
@@ -7,7 +7,6 @@ export interface WorkflowConfig {
 }
 
 export interface SignPdfRequest {
-  readonly originalFilename: string;
   readonly pdfBytes: SerializedBytes;
   readonly senderLastname: string;
 }

--- a/src/shared/messages.ts
+++ b/src/shared/messages.ts
@@ -15,10 +15,26 @@ export type SignPdfResponse =
   | { readonly error: string; readonly success: false }
   | { readonly filename: string; readonly signedPdf: SerializedBytes; readonly success: true };
 
-export interface WorkflowResult {
+export interface DraftError {
+  readonly index: number;
   readonly message: string;
-  readonly success: boolean;
 }
+
+export type WorkflowResult =
+  | {
+      readonly kind: "processed";
+      readonly success: true;
+      readonly successCount: number;
+      readonly totalCount: number;
+    }
+  | {
+      readonly kind: "partial-failure";
+      readonly success: false;
+      readonly successCount: number;
+      readonly totalCount: number;
+      readonly draftErrors: readonly DraftError[];
+    }
+  | { readonly kind: "workflow-error"; readonly success: false; readonly error: string };
 
 export interface ContentToBackgroundMessage {
   readonly payload: SignPdfRequest;

--- a/src/shared/pdf.test.ts
+++ b/src/shared/pdf.test.ts
@@ -1,9 +1,6 @@
-import { PDFDocument } from "pdf-lib";
 import { describe, expect, test } from "vite-plus/test";
 
 import { generateAttachmentName, getSignatureFormat, getTargetMonthAndYear } from "./pdf.js";
-import { extractEmail, extractLastname } from "./sender.js";
-import { signPdf } from "./signer.js";
 
 describe("getTargetMonthAndYear", () => {
   test("returns month based on day threshold", () => {
@@ -41,46 +38,6 @@ describe("generateAttachmentName", () => {
   });
 });
 
-describe("extractLastname", () => {
-  test("extracts lastname from various formats", () => {
-    expect([
-      extractLastname("From: DUPONT Jean"),
-      extractLastname("From: DE LA TOUR Pierre"),
-      extractLastname("From: Jean Dupont"),
-      extractLastname("From: Admin"),
-      extractLastname("From: MARTIN Sophie <sophie.martin@example.com>"),
-      extractLastname("From:   "),
-      extractLastname("From: A Jean Dupont"),
-    ]).toEqual(["DUPONT", "DE LA TOUR", "Dupont", "Admin", "MARTIN", "", "Dupont"]);
-  });
-
-  test("skips single-char uppercase parts", () => {
-    expect(extractLastname("A DUPONT Jean")).toBe("Jean");
-  });
-});
-
-describe("extractEmail", () => {
-  test("extracts email from various formats", () => {
-    expect([
-      extractEmail("John Doe <john.doe@example.com>"),
-      extractEmail("Contact: john.doe@example.com for more info"),
-      extractEmail("<user+tag@example.com>"),
-      extractEmail("John Doe"),
-      extractEmail("alias@old.com <real@example.com>"),
-    ]).toEqual([
-      "john.doe@example.com",
-      "john.doe@example.com",
-      "user+tag@example.com",
-      "",
-      "real@example.com",
-    ]);
-  });
-
-  test("returns empty string for empty input", () => {
-    expect(extractEmail("")).toBe("");
-  });
-});
-
 describe("getSignatureFormat", () => {
   test("detects image format from filename", () => {
     expect([
@@ -95,79 +52,5 @@ describe("getSignatureFormat", () => {
     expect(() => getSignatureFormat("signature.gif")).toThrow(
       'Unsupported signature format: "signature.gif". Only .png, .jpg, .jpeg are supported.',
     );
-  });
-});
-
-const MINIMAL_PNG_BASE64 =
-  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVQI12P4z8AAAAACAAHiIbwzAAAAAElFTkSuQmCC";
-const MINIMAL_PNG = Uint8Array.from(atob(MINIMAL_PNG_BASE64), (char) => char.codePointAt(0) ?? 0);
-
-async function createTestPdf(): Promise<Uint8Array> {
-  const doc = await PDFDocument.create();
-  doc.addPage();
-  return doc.save();
-}
-
-describe("signPdf", () => {
-  test("returns valid PDF bytes with embedded signature", async () => {
-    // Given
-    const pdfBytes = await createTestPdf();
-    const position = { height: 50, width: 100, x: 50, y: 50 };
-
-    // When
-    const result = await signPdf({
-      format: "png",
-      pdfBytes: new Uint8Array(pdfBytes),
-      position,
-      sigBytes: MINIMAL_PNG,
-    });
-
-    // Then
-    expect({
-      hasPdfHeader: new TextDecoder().decode(result.slice(0, 5)) === "%PDF-",
-      isUint8Array: result instanceof Uint8Array,
-      nonEmpty: result.length > 0,
-    }).toEqual({
-      hasPdfHeader: true,
-      isUint8Array: true,
-      nonEmpty: true,
-    });
-  });
-
-  test("output is larger than input due to embedded image", async () => {
-    // Given
-    const pdfBytes = await createTestPdf();
-
-    // When
-    const result = await signPdf({
-      format: "png",
-      pdfBytes: new Uint8Array(pdfBytes),
-      position: { height: 10, width: 10, x: 0, y: 0 },
-      sigBytes: MINIMAL_PNG,
-    });
-
-    // Then
-    expect(result.length).toBeGreaterThan(pdfBytes.length);
-  });
-
-  test("signs on the last page of a multi-page PDF", async () => {
-    // Given
-    const doc = await PDFDocument.create();
-    doc.addPage();
-    doc.addPage();
-    doc.addPage();
-    const pdfBytes = await doc.save();
-
-    // When
-    const result = await signPdf({
-      format: "png",
-      pdfBytes: new Uint8Array(pdfBytes),
-      position: { height: 25, width: 50, x: 10, y: 10 },
-      sigBytes: MINIMAL_PNG,
-    });
-
-    // Then
-    const resultDoc = await PDFDocument.load(result);
-    expect(resultDoc.getPageCount()).toBe(3);
   });
 });

--- a/src/shared/sender.test.ts
+++ b/src/shared/sender.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "vite-plus/test";
+
+import { extractEmail, extractLastname } from "./sender.js";
+
+describe("extractLastname", () => {
+  test("extracts lastname from various formats", () => {
+    expect([
+      extractLastname("From: DUPONT Jean"),
+      extractLastname("From: DE LA TOUR Pierre"),
+      extractLastname("From: Jean Dupont"),
+      extractLastname("From: Admin"),
+      extractLastname("From: MARTIN Sophie <sophie.martin@example.com>"),
+      extractLastname("From:   "),
+      extractLastname("From: A Jean Dupont"),
+    ]).toEqual(["DUPONT", "DE LA TOUR", "Dupont", "Admin", "MARTIN", "", "Dupont"]);
+  });
+
+  test("skips single-char uppercase parts", () => {
+    expect(extractLastname("A DUPONT Jean")).toBe("Jean");
+  });
+});
+
+describe("extractEmail", () => {
+  test("extracts email from various formats", () => {
+    expect([
+      extractEmail("John Doe <john.doe@example.com>"),
+      extractEmail("Contact: john.doe@example.com for more info"),
+      extractEmail("<user+tag@example.com>"),
+      extractEmail("John Doe"),
+      extractEmail("alias@old.com <real@example.com>"),
+    ]).toEqual([
+      "john.doe@example.com",
+      "john.doe@example.com",
+      "user+tag@example.com",
+      "",
+      "real@example.com",
+    ]);
+  });
+
+  test("returns empty string for empty input", () => {
+    expect(extractEmail("")).toBe("");
+  });
+});

--- a/src/shared/signer.test.ts
+++ b/src/shared/signer.test.ts
@@ -1,0 +1,78 @@
+import { PDFDocument } from "pdf-lib";
+import { describe, expect, test } from "vite-plus/test";
+
+import { signPdf } from "./signer.js";
+
+const MINIMAL_PNG_BASE64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVQI12P4z8AAAAACAAHiIbwzAAAAAElFTkSuQmCC";
+const MINIMAL_PNG = Uint8Array.from(atob(MINIMAL_PNG_BASE64), (char) => char.codePointAt(0) ?? 0);
+
+async function createTestPdf(): Promise<Uint8Array> {
+  const doc = await PDFDocument.create();
+  doc.addPage();
+  return doc.save();
+}
+
+describe("signPdf", () => {
+  test("returns valid PDF bytes with embedded signature", async () => {
+    // Given
+    const pdfBytes = await createTestPdf();
+    const position = { height: 50, width: 100, x: 50, y: 50 };
+
+    // When
+    const result = await signPdf({
+      format: "png",
+      pdfBytes: new Uint8Array(pdfBytes),
+      position,
+      sigBytes: MINIMAL_PNG,
+    });
+
+    // Then
+    expect({
+      hasPdfHeader: new TextDecoder().decode(result.slice(0, 5)) === "%PDF-",
+      isUint8Array: result instanceof Uint8Array,
+      nonEmpty: result.length > 0,
+    }).toEqual({
+      hasPdfHeader: true,
+      isUint8Array: true,
+      nonEmpty: true,
+    });
+  });
+
+  test("output is larger than input due to embedded image", async () => {
+    // Given
+    const pdfBytes = await createTestPdf();
+
+    // When
+    const result = await signPdf({
+      format: "png",
+      pdfBytes: new Uint8Array(pdfBytes),
+      position: { height: 10, width: 10, x: 0, y: 0 },
+      sigBytes: MINIMAL_PNG,
+    });
+
+    // Then
+    expect(result.length).toBeGreaterThan(pdfBytes.length);
+  });
+
+  test("signs on the last page of a multi-page PDF", async () => {
+    // Given
+    const doc = await PDFDocument.create();
+    doc.addPage();
+    doc.addPage();
+    doc.addPage();
+    const pdfBytes = await doc.save();
+
+    // When
+    const result = await signPdf({
+      format: "png",
+      pdfBytes: new Uint8Array(pdfBytes),
+      position: { height: 25, width: 50, x: 10, y: 10 },
+      sigBytes: MINIMAL_PNG,
+    });
+
+    // Then
+    const resultDoc = await PDFDocument.load(result);
+    expect(resultDoc.getPageCount()).toBe(3);
+  });
+});


### PR DESCRIPTION
## Summary

Addresses 23 defects surfaced by two rounds of blind subjective review across 20 code-quality dimensions. Strict desloppify score moved from 91.9 → re-review pending (after commit `1bbaaf4`).

**Commit 1 (`49cb89d`) — 11 findings:**
- CLAUDE.md: fix main-world description (URL.createObjectURL, not XMLHttpRequest) + add signer.ts to shared/ tree
- Drop unused `originalFilename` field from `SignPdfRequest` contract and all producers/tests
- `main-world.ts`: wrap patch + listener in `installMainWorld()` with teardown closure; add `event.origin` guard
- Add happy + error path tests for `outlook-dom`, `outlook-compose`, `outlook-download`

**Commit 2 (`1bbaaf4`) — 12 findings:**
- Split main-world bootstrap into `main-world-entry.ts` so install/uninstall is controllable; tests now use the lifecycle
- Rename `content.ts` `signPdf` → `requestSignPdf` (no longer shadows `shared/signer.signPdf`)
- Slim `SignedPdfItem` and `PdfAttachment` to only fields consumers read
- Discriminate `WorkflowResult` into `processed` / `partial-failure` / `workflow-error`; move presentation formatting to `popup.ts`
- `DraftResult.errors` carries structured `DraftError[]` with `index`, not pre-formatted strings
- Extract `captureAndFetchPdf(trigger)` helper encoding the subscribe-then-trigger invariant structurally
- Tighten `isBlobMessage` / `isBlobCaptured` / `isBlobResult` to check `id` / `url` / `data` / `error` types, not just key presence
- Split `sender.test.ts` and `signer.test.ts` from `pdf.test.ts` (restore 1:1 source/test pairing)
- Strip `catch (error: unknown)` annotation from `main-world.ts` to match the other six try/catch sites
- Add sign/draft pipeline tests covering happy path, sign failure, and partial draft failure

## Test plan

- [x] `vp check` — fmt + lint + typecheck pass (81 files formatted, 55 lint/type-clean)
- [x] `vp test` — 101 unit tests / 20 files pass
- [x] `vp run test:e2e` — 22 Playwright tests pass
- [ ] Smoke-test the packaged extension in Outlook Web (manual)

🤖 Generated with [Claude Code](https://claude.com/claude-code)