### PR TITLE
Add pnpm supply chain security settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,11 +24,5 @@
     "knip": "6.14.0",
     "vite-plus": "0.1.20"
   },
-  "packageManager": "pnpm@10.33.0",
-  "pnpm": {
-    "overrides": {
-      "vite": "npm:@voidzero-dev/vite-plus-core@0.1.18",
-      "vitest": "npm:@voidzero-dev/vite-plus-test@0.1.18"
-    }
-  }
+  "packageManager": "pnpm@11.1.3"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,8 +5,8 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  vite: npm:@voidzero-dev/vite-plus-core@0.1.18
-  vitest: npm:@voidzero-dev/vite-plus-test@0.1.18
+  vite: npm:@voidzero-dev/vite-plus-core@0.1.20
+  vitest: npm:@voidzero-dev/vite-plus-test@0.1.20
 
 importers:
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,10 +4,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-overrides:
-  vite: npm:@voidzero-dev/vite-plus-core@0.1.20
-  vitest: npm:@voidzero-dev/vite-plus-test@0.1.20
-
 importers:
 
   .:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,15 @@
+# pnpm supply chain security settings — https://pnpm.io/supply-chain-security
+# Aligned with .github/dependabot.yml `cooldown.default-days: 3`.
+
+# Refuse to install package versions younger than 3 days (4320 minutes).
+# Matches Dependabot's 3-day cooldown so local `vp install` is gated the same way.
+minimumReleaseAge: 4320
+
+# Block transitive deps from resolving to git repos or arbitrary tarball URLs.
+# Default became `true` in pnpm 10.26; set explicitly so the guarantee survives
+# any future default change.
+blockExoticSubdeps: true
+
+# Refuse packages whose npm trust level (provenance, 2FA, etc.) has been
+# downgraded compared to a previously installed version.
+trustPolicy: no-downgrade

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,11 @@
-# pnpm supply chain security settings — https://pnpm.io/supply-chain-security
+# pnpm v11 settings — https://pnpm.io/settings
+# (pnpm v11 ignores the `pnpm.*` field in package.json.)
+
+overrides:
+  vite: npm:@voidzero-dev/vite-plus-core@0.1.18
+  vitest: npm:@voidzero-dev/vite-plus-test@0.1.18
+
+# Supply chain security — https://pnpm.io/supply-chain-security
 # Aligned with .github/dependabot.yml `cooldown.default-days: 3`.
 
 # Refuse to install package versions younger than 3 days (4320 minutes).
@@ -13,3 +20,7 @@ blockExoticSubdeps: true
 # Refuse packages whose npm trust level (provenance, 2FA, etc.) has been
 # downgraded compared to a previously installed version.
 trustPolicy: no-downgrade
+
+# v11+: fail resolution when a package's registry metadata is missing the
+# `time` field, instead of silently bypassing the minimumReleaseAge check.
+minimumReleaseAgeIgnoreMissingTime: false

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,11 +1,4 @@
-# pnpm v11 settings — https://pnpm.io/settings
-# (pnpm v11 ignores the `pnpm.*` field in package.json.)
-
-overrides:
-  vite: npm:@voidzero-dev/vite-plus-core@0.1.20
-  vitest: npm:@voidzero-dev/vite-plus-test@0.1.20
-
-# Supply chain security — https://pnpm.io/supply-chain-security
+# pnpm supply chain security — https://pnpm.io/supply-chain-security
 # Aligned with .github/dependabot.yml `cooldown.default-days: 3`.
 
 # Refuse to install package versions younger than 3 days (4320 minutes).

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,8 +2,8 @@
 # (pnpm v11 ignores the `pnpm.*` field in package.json.)
 
 overrides:
-  vite: npm:@voidzero-dev/vite-plus-core@0.1.18
-  vitest: npm:@voidzero-dev/vite-plus-test@0.1.18
+  vite: npm:@voidzero-dev/vite-plus-core@0.1.20
+  vitest: npm:@voidzero-dev/vite-plus-test@0.1.20
 
 # Supply chain security — https://pnpm.io/supply-chain-security
 # Aligned with .github/dependabot.yml `cooldown.default-days: 3`.


### PR DESCRIPTION
Aligns local installs with Dependabot's 3-day cooldown and applies
hardenings from https://pnpm.io/supply-chain-security:

- minimumReleaseAge: 4320 (3 days, matches dependabot.yml cooldown)
- blockExoticSubdeps: true (no git/tarball transitive deps)
- trustPolicy: no-downgrade (block packages with degraded provenance)