### PR TITLE
Fix CI lint failures by switching to default `node:path` imports

### DIFF
--- a/build.ts
+++ b/build.ts
@@ -1,6 +1,6 @@
 import { cpSync, existsSync } from "node:fs";
 import { mkdir, rm } from "node:fs/promises";
-import { join } from "node:path";
+import path from "node:path";
 
 import { build } from "vite-plus";
 
@@ -27,7 +27,7 @@ async function buildEntry(entry: string): Promise<void> {
       target: "esnext",
       modulePreload: false,
       lib: {
-        entry: join(SRC_DIR, `${entry}.ts`),
+        entry: path.join(SRC_DIR, `${entry}.ts`),
         formats: ["es"],
         fileName: () => `${entry}.js`,
       },
@@ -42,11 +42,11 @@ async function buildEntry(entry: string): Promise<void> {
 }
 
 async function copyStatic(): Promise<void> {
-  cpSync("manifest.json", join(DIST_DIR, "manifest.json"));
-  cpSync(join(SRC_DIR, "popup/popup.html"), join(DIST_DIR, "popup/popup.html"));
-  cpSync(join(SRC_DIR, "options/options.html"), join(DIST_DIR, "options/options.html"));
+  cpSync("manifest.json", path.join(DIST_DIR, "manifest.json"));
+  cpSync(path.join(SRC_DIR, "popup/popup.html"), path.join(DIST_DIR, "popup/popup.html"));
+  cpSync(path.join(SRC_DIR, "options/options.html"), path.join(DIST_DIR, "options/options.html"));
   if (existsSync("icons")) {
-    cpSync("icons", join(DIST_DIR, "icons"), { recursive: true });
+    cpSync("icons", path.join(DIST_DIR, "icons"), { recursive: true });
   }
 }
 

--- a/e2e/helpers/extension-context.ts
+++ b/e2e/helpers/extension-context.ts
@@ -1,12 +1,12 @@
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import path from "node:path";
 
 import { type BrowserContext, type Page, chromium } from "@playwright/test";
 
 import { type MockConfig, createChromeMock } from "#mocks/chrome-api.js";
 
-const PATH_TO_EXTENSION = join(import.meta.dirname, "../../dist");
+const PATH_TO_EXTENSION = path.join(import.meta.dirname, "../../dist");
 
 export async function createExtensionContext(): Promise<{
   close: () => Promise<void>;
@@ -14,7 +14,7 @@ export async function createExtensionContext(): Promise<{
   extensionId: string;
   getPopupPage: () => Promise<Page>;
 }> {
-  const userDataDir = await mkdtemp(join(tmpdir(), "opm-test-"));
+  const userDataDir = await mkdtemp(path.join(tmpdir(), "opm-test-"));
   const context = await chromium.launchPersistentContext(userDataDir, {
     args: [
       `--disable-extensions-except=${PATH_TO_EXTENSION}`,

--- a/e2e/helpers/extension-fixture.ts
+++ b/e2e/helpers/extension-fixture.ts
@@ -1,11 +1,11 @@
 import { readFile } from "node:fs/promises";
-import { join } from "node:path";
+import path from "node:path";
 
 import { type BrowserContext, type Page, test as base } from "@playwright/test";
 
 import { createExtensionContext } from "./extension-context.js";
 
-const FIXTURES_DIR = join(import.meta.dirname, "../fixtures");
+const FIXTURES_DIR = path.join(import.meta.dirname, "../fixtures");
 
 interface ExtensionWorkerFixtures {
   extensionContext: BrowserContext;
@@ -85,7 +85,7 @@ export default base.extend<ExtensionTestFixtures, ExtensionWorkerFixtures>({
     use,
   ) => {
     await use(async (fixtureName: string) => {
-      const fixturePath = join(FIXTURES_DIR, fixtureName);
+      const fixturePath = path.join(FIXTURES_DIR, fixtureName);
       const html = await readFile(fixturePath, "utf8");
       const page = await extensionContext.newPage();
 

--- a/e2e/tests/content-script.spec.ts
+++ b/e2e/tests/content-script.spec.ts
@@ -1,9 +1,9 @@
-import { join } from "node:path";
+import path from "node:path";
 
 import { type Page, expect, test } from "@playwright/test";
 
-const FIXTURES_DIR = join(import.meta.dirname, "../fixtures");
-const FIXTURE_PATH = join(FIXTURES_DIR, "outlook-message.html");
+const FIXTURES_DIR = path.join(import.meta.dirname, "../fixtures");
+const FIXTURE_PATH = path.join(FIXTURES_DIR, "outlook-message.html");
 
 // DOM query smoke tests against HTML fixtures. Algorithm logic is tested in outlook-actions.test.ts.
 test.describe("Content Script DOM Queries", () => {
@@ -105,7 +105,7 @@ test.describe("Content Script DOM Queries", () => {
     page,
   }: Readonly<{ page: Readonly<Page> }>) => {
     // Given: page with only own messages
-    await page.goto(`file://${join(FIXTURES_DIR, "outlook-only-own-messages.html")}`);
+    await page.goto(`file://${path.join(FIXTURES_DIR, "outlook-only-own-messages.html")}`);
 
     // When: searching for last message from others
     const result = await page.evaluate(() => {
@@ -139,7 +139,7 @@ test.describe("Content Script DOM Queries", () => {
     page,
   }: Readonly<{ page: Readonly<Page> }>) => {
     // Given: page with no heading element
-    await page.goto(`file://${join(FIXTURES_DIR, "outlook-no-subject.html")}`);
+    await page.goto(`file://${path.join(FIXTURES_DIR, "outlook-no-subject.html")}`);
 
     // When
     const heading = await page.locator('[role="main"] [role="heading"][aria-level="2"]').count();

--- a/e2e/tests/popup.spec.ts
+++ b/e2e/tests/popup.spec.ts
@@ -1,8 +1,8 @@
-import { join } from "node:path";
+import path from "node:path";
 
 import { type Page, expect, test } from "@playwright/test";
 
-const POPUP_PATH = join(import.meta.dirname, "../../dist/popup/popup.html");
+const POPUP_PATH = path.join(import.meta.dirname, "../../dist/popup/popup.html");
 
 test("popup initial state", async ({ page }: Readonly<{ page: Readonly<Page> }>) => {
   // Given

--- a/e2e/tests/workflow.spec.ts
+++ b/e2e/tests/workflow.spec.ts
@@ -1,10 +1,10 @@
-import { join } from "node:path";
+import path from "node:path";
 
 import { type Page, expect, test } from "@playwright/test";
 
-const FIXTURES = join(import.meta.dirname, "../fixtures");
-const INBOX_FIXTURE = join(FIXTURES, "outlook-inbox.html");
-const MESSAGE_FIXTURE = join(FIXTURES, "outlook-message.html");
+const FIXTURES = path.join(import.meta.dirname, "../fixtures");
+const INBOX_FIXTURE = path.join(FIXTURES, "outlook-inbox.html");
+const MESSAGE_FIXTURE = path.join(FIXTURES, "outlook-message.html");
 
 test.describe("Workflow DOM Interactions", () => {
   test("inbox fixture has conversations with subject", async ({

--- a/src/content/outlook-compose.ts
+++ b/src/content/outlook-compose.ts
@@ -8,6 +8,7 @@ import {
   removeAllAttachments,
   saveDraft,
 } from "./outlook-compose-actions.js";
+
 export interface SignedPdfItem {
   readonly conversationId: string;
   readonly filename: string;


### PR DESCRIPTION
### Motivation
- Linting started failing due to the `unicorn(import-style)` rule that requires default imports for `node:path`, so CI needed updates to satisfy the linter.
- Tests and formatting tooling require consistent import style across build scripts and e2e helpers to keep CI green.

### Description
- Replaced named `join` imports from `node:path` with default `path` imports and updated call sites to use `path.join` in `build.ts`, `e2e/helpers/extension-context.ts`, `e2e/helpers/extension-fixture.ts`, and several e2e tests under `e2e/tests/`.
- Updated `e2e` helpers and specs to use `path.join(...)` for fixture and dist path construction.
- Preserved the formatted blank line after compose imports in `src/content/outlook-compose.ts` to satisfy the import/newline lint rule.

### Testing
- Ran `corepack pnpm install --frozen-lockfile` which completed successfully.
- Ran lint/format/type checks with `corepack pnpm exec vp check` which passed after the fixes.
- Ran static checks and build steps with `corepack pnpm exec knip`, `corepack pnpm run jscpd`, and `corepack pnpm run build`, all of which completed successfully and produced `./dist`.
- Ran unit tests with `corepack pnpm exec vp test run --coverage --reporter=junit --outputFile=./junit.xml` which executed and wrote `junit.xml` successfully.
- Attempted e2e browser install and `corepack pnpm run test:e2e` but Playwright browser download failed in this environment due to a `403 Domain forbidden` from `cdn.playwright.dev`, so e2e tests could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a210306242883308fb5a53e89e527f8)