### PR TITLE
Configure Renovate for pnpm maintenance

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,5 +24,5 @@
     "knip": "6.15.0",
     "vite-plus": "0.1.23"
   },
-  "packageManager": "pnpm@11.1.3"
+  "packageManager": "pnpm@11.5.1"
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [":maintainLockFilesWeekly"],
+  "enabledManagers": ["npm"],
+  "packageRules": [
+    {
+      "matchManagers": ["npm"],
+      "enabled": false
+    },
+    {
+      "matchManagers": ["npm"],
+      "matchDepTypes": ["packageManager"],
+      "enabled": true,
+      "minimumReleaseAge": "3 days",
+      "prCreation": "not-pending",
+      "internalChecksFilter": "strict"
+    },
+    {
+      "matchManagers": ["npm"],
+      "matchUpdateTypes": ["lockFileMaintenance"],
+      "enabled": true
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- update the pnpm package manager pin from 11.1.3 to 11.5.1
- use Renovate for `packageManager` updates, which Dependabot does not manage
- enable weekly pnpm lockfile maintenance
- keep regular npm dependency updates owned by Dependabot
- preserve the three-day release cooldown for pnpm updates

## Verification

- `vp install`
- `vp check`
- `renovate-config-validator renovate.json`